### PR TITLE
Gibbs sampling step for logistic regression

### DIFF
--- a/src/jnotype/logistic/_polyagamma.py
+++ b/src/jnotype/logistic/_polyagamma.py
@@ -11,9 +11,10 @@ from jaxtyping import Array, Int, Float
 
 def _calculate_logits(
     coefficients: Float[Array, "features covariates"],
+    structure: Int[Array, "features covariates"],
     covariates: Float[Array, "points covariates"],
 ) -> Float[Array, "points features"]:
-    return jnp.einsum("FC,NC->NF", coefficients, covariates)
+    return jnp.einsum("FC,FC,NC->NF", coefficients, structure, covariates)
 
 
 _calculate_logits_jit = jax.jit(_calculate_logits)
@@ -24,14 +25,27 @@ def _sample_coefficients(
     key: random.PRNGKeyArray,
     omega: Float[Array, "points features"],
     covariates: Float[Array, "points covariates"],
+    structure: Int[Array, "features covariates"],
     prior_mean: Float[Array, "features covariates"],
     prior_variance: Float[Array, "features covariates"],
     observed: Int[Array, "points features"],
 ) -> Float[Array, "features covariates"]:
     """The backend of `sample_coefficients`, which has access
     to the auxiliary Pólya-Gamma variables."""
+
+    # This bit requires some explanation. If F=1 and we have only one
+    # output, we want to have
+    # matrix[c, k] = sum_n  X[n, k] omega[n] X[n, c]
+    # However, we have F outputs and each of them has access to different
+    # covariates due to the sparsity structure!
+    # The covariates are U[f, n, c] = X[n, c] * structure[f, c]
     x_omega_x: Float[Array, "features covariates covariates"] = jnp.einsum(
-        "NC,NF,NK->FKC", covariates, omega, covariates
+        "NC,FC,NF,NK,FK->FCK",
+        covariates,
+        structure,
+        omega,
+        covariates,
+        structure,
     )
     precision_matrices: Float[Array, "features covariates covariates"] = jax.vmap(
         jnp.diag
@@ -42,7 +56,8 @@ def _sample_coefficients(
 
     kappa: Float[Array, "points features"] = jnp.asarray(observed, dtype=float) - 0.5
 
-    bracket = jnp.einsum("NC,NF->FC", covariates, kappa) + jnp.einsum(
+    # Check if this is right...
+    bracket = jnp.einsum("NC,FC,NF->FC", covariates, structure, kappa) + jnp.einsum(
         "FCK,FK->FC", posterior_covariances, prior_mean
     )
     posterior_means: Float[Array, "features covariates"] = jnp.einsum(
@@ -60,11 +75,13 @@ _sample_coefficients_jit = jax.jit(_sample_coefficients)
 
 
 def sample_coefficients(
+    *,
     jax_key: random.PRNGKeyArray,
     numpy_rng: np.random.Generator,
     observed: Int[Array, "points features"],
     design_matrix: Float[Array, "points covariates"],
     coefficients: Float[Array, "features covariates"],
+    structure: Int[Array, "features covariates"],
     coefficients_prior_mean: Float[Array, "features covariates"],
     coefficients_prior_variance: Float[Array, "features covariates"],
 ) -> Float[Array, "features covariates"]:
@@ -76,7 +93,11 @@ def sample_coefficients(
         or vmapped.
     """
     # Calculate logits using JITted code
-    logits = _calculate_logits_jit(coefficients=coefficients, covariates=design_matrix)
+    logits = _calculate_logits_jit(
+        coefficients=coefficients,
+        covariates=design_matrix,
+        structure=structure,
+    )
 
     # Use Pólya-Gamma sampler to sample auxiliary variables omega
     omega: Float[Array, "points features"] = jnp.asarray(
@@ -88,7 +109,157 @@ def sample_coefficients(
         key=jax_key,
         omega=omega,
         covariates=design_matrix,
+        structure=structure,
         prior_mean=coefficients_prior_mean,
         prior_variance=coefficients_prior_variance,
         observed=observed,
     )
+
+
+def _augment(matrix: Float[Array, "a b"]) -> Float[Array, "a b+1"]:
+    n_points = matrix.shape[0]
+    return jnp.hstack(
+        (
+            jnp.ones((n_points, 1)),
+            matrix,
+        )
+    )
+
+
+def _augmented_mean(
+    intercept_prior_mean: float,
+    augmented_coefficients: Float[Array, "features entries"],
+) -> Float[Array, "features entries"]:
+    n_features, n_augmented_covs = augmented_coefficients.shape
+    n_covs = n_augmented_covs - 1
+
+    return jnp.hstack(
+        (
+            jnp.full(shape=(n_features, 1), fill_value=intercept_prior_mean),
+            jnp.zeros(shape=(n_features, n_covs)),
+        )
+    )
+
+
+def _augmented_variances(
+    intercept_variance: float,
+    variance_per_covariate: Float[Array, " covariates"],
+    structure: Int[Array, "features covariates"],
+    pseudoprior_variance: float,
+) -> Float[Array, "features covariates+1"]:
+    # Shape (features, covariates)
+    coefficient_variances = (
+        structure * jnp.full(shape=structure.shape, fill_value=variance_per_covariate)
+        + (1 - structure) * pseudoprior_variance
+    )
+
+    return jnp.hstack(
+        (
+            jnp.full(shape=(structure.shape[0], 1), fill_value=intercept_variance),
+            coefficient_variances,
+        )
+    )
+
+
+@jax.jit
+def _augment_matrices(
+    *,
+    intercepts,
+    covariates,
+    coefficients,
+    structure,
+    intercept_prior_mean,
+    intercept_prior_variance,
+    pseudoprior_variance,
+    variances,
+) -> dict:
+    # Create design matrix, storing intercepts
+    # using the augmented design
+    # Shape (points, covs+1)
+    augmented_covariates = _augment(covariates)
+
+    # Shape (features, covs+1)
+    augmented_coefficients = jnp.hstack((intercepts.reshape((-1, 1)), coefficients))
+
+    # Shape (features, covs+1)
+    augmented_structure = _augment(structure)
+
+    # Now construct the prior matrices,
+    # remembering about the pseudoprior
+    # controlled by structure
+    # Shape (covs+1,)
+    augmented_prior_mean = _augmented_mean(
+        intercept_prior_mean=intercept_prior_mean,
+        augmented_coefficients=augmented_coefficients,
+    )
+    # Shape (features, covs+1)
+    augmented_prior_variances = _augmented_variances(
+        pseudoprior_variance=pseudoprior_variance,
+        structure=structure,
+        intercept_variance=intercept_prior_variance,
+        variance_per_covariate=variances,
+    )
+
+    return {
+        "covariates": augmented_covariates,
+        "coefficients": augmented_coefficients,
+        "structure": augmented_structure,
+        "prior_mean": augmented_prior_mean,
+        "prior_variance": augmented_prior_variances,
+    }
+
+
+def sample_intercepts_and_coefficients(
+    jax_key: random.PRNGKeyArray,
+    numpy_rng: np.random.Generator,
+    observed: Int[Array, "points features"],
+    intercepts: Float[Array, " features"],
+    coefficients: Float[Array, "features covs"],
+    structure: Int[Array, "features covs"],
+    covariates: Float[Array, "points covs"],
+    variances: Float[Array, " covs"],
+    pseudoprior_variance: float,
+    intercept_prior_mean: float,
+    intercept_prior_variance: float,
+) -> tuple[Float[Array, " features"], Float[Array, "features covs"]]:
+    """Samples coefficients and intercepts.
+
+    Note:
+        This uses the augmentation trick, i.e.
+          X_aug = (1, X),
+          coefs_aug = (intercept, coefs_aug),
+          structure_aug = (1, structure),
+        samples new version of `coefs_aug`
+        and then splits it again into intercepts
+        and coefficients.
+    """
+    augmented = _augment_matrices(
+        intercepts=intercepts,
+        covariates=covariates,
+        coefficients=coefficients,
+        structure=structure,
+        intercept_prior_mean=intercept_prior_mean,
+        intercept_prior_variance=intercept_prior_variance,
+        pseudoprior_variance=pseudoprior_variance,
+        variances=variances,
+    )
+
+    # Let's sample the augmented (features, covs+1)
+    # coefficients
+    augmented_sampled = sample_coefficients(
+        jax_key=jax_key,
+        numpy_rng=numpy_rng,
+        observed=observed,
+        design_matrix=augmented["covariates"],
+        coefficients=augmented["coefficients"],
+        structure=augmented["structure"],
+        coefficients_prior_mean=augmented["prior_mean"],
+        coefficients_prior_variance=augmented["prior_variance"],
+    )
+
+    # Now we split the sampled augmented coefficients
+    # into intercepts and the rest
+    intercepts_sampled = augmented_sampled[:, 0]
+    coefficients_sampled = augmented_sampled[:, 1:]
+
+    return intercepts_sampled, coefficients_sampled

--- a/src/jnotype/logistic/_polyagamma.py
+++ b/src/jnotype/logistic/_polyagamma.py
@@ -58,7 +58,7 @@ def _sample_coefficients(
 
     # Check if this is right...
     bracket = jnp.einsum("NC,FC,NF->FC", covariates, structure, kappa) + jnp.einsum(
-        "FCK,FK->FC", posterior_covariances, prior_mean
+        "FCK,FK->FC", precision_matrices, prior_mean
     )
     posterior_means: Float[Array, "features covariates"] = jnp.einsum(
         "FCK,FK->FC", posterior_covariances, bracket

--- a/src/jnotype/logistic/_polyagamma.py
+++ b/src/jnotype/logistic/_polyagamma.py
@@ -1,0 +1,94 @@
+"""Logistic regression sampling utilities using Pólya-Gamma augmentation."""
+from jax import random
+import jax
+import jax.numpy as jnp
+
+import numpy as np
+import polyagamma as pg
+
+from jaxtyping import Array, Int, Float
+
+
+def _calculate_logits(
+    coefficients: Float[Array, "features covariates"],
+    covariates: Float[Array, "points covariates"],
+) -> Float[Array, "points features"]:
+    return jnp.einsum("FC,NC->NF", coefficients, covariates)
+
+
+_calculate_logits_jit = jax.jit(_calculate_logits)
+
+
+def _sample_coefficients(
+    *,
+    key: random.PRNGKeyArray,
+    omega: Float[Array, "points features"],
+    covariates: Float[Array, "points covariates"],
+    prior_mean: Float[Array, "features covariates"],
+    prior_variance: Float[Array, "features covariates"],
+    observed: Int[Array, "points features"],
+) -> Float[Array, "features covariates"]:
+    """The backend of `sample_coefficients`, which has access
+    to the auxiliary Pólya-Gamma variables."""
+    x_omega_x: Float[Array, "features covariates covariates"] = jnp.einsum(
+        "NC,NF,NK->FKC", covariates, omega, covariates
+    )
+    precision_matrices: Float[Array, "features covariates covariates"] = jax.vmap(
+        jnp.diag
+    )(jnp.reciprocal(prior_variance))
+    posterior_covariances: Float[
+        Array, "features covariates covariates"
+    ] = jnp.linalg.inv(x_omega_x + precision_matrices)
+
+    kappa: Float[Array, "points features"] = jnp.asarray(observed, dtype=float) - 0.5
+
+    bracket = jnp.einsum("NC,NF->FC", covariates, kappa) + jnp.einsum(
+        "FCK,FK->FC", posterior_covariances, prior_mean
+    )
+    posterior_means: Float[Array, "features covariates"] = jnp.einsum(
+        "FCK,FK->FC", posterior_covariances, bracket
+    )
+
+    return random.multivariate_normal(
+        key,
+        mean=posterior_means,
+        cov=posterior_covariances,
+    )
+
+
+_sample_coefficients_jit = jax.jit(_sample_coefficients)
+
+
+def sample_coefficients(
+    jax_key: random.PRNGKeyArray,
+    numpy_rng: np.random.Generator,
+    observed: Int[Array, "points features"],
+    design_matrix: Float[Array, "points covariates"],
+    coefficients: Float[Array, "features covariates"],
+    coefficients_prior_mean: Float[Array, "features covariates"],
+    coefficients_prior_variance: Float[Array, "features covariates"],
+) -> Float[Array, "features covariates"]:
+    """
+
+    Note:
+        This function uses Pólya-Gamma sampler, which is *not*
+        compatible with JAX! Therefore, it cannot be compiled
+        or vmapped.
+    """
+    # Calculate logits using JITted code
+    logits = _calculate_logits_jit(coefficients=coefficients, covariates=design_matrix)
+
+    # Use Pólya-Gamma sampler to sample auxiliary variables omega
+    omega: Float[Array, "points features"] = jnp.asarray(
+        pg.random_polyagamma(1, z=logits, random_state=numpy_rng), dtype=float
+    )
+
+    # Sample the coefficients using JITted code which is given auxiliary variables
+    return _sample_coefficients_jit(
+        key=jax_key,
+        omega=omega,
+        covariates=design_matrix,
+        prior_mean=coefficients_prior_mean,
+        prior_variance=coefficients_prior_variance,
+        observed=observed,
+    )

--- a/tests/logistic/test_polyagamma.py
+++ b/tests/logistic/test_polyagamma.py
@@ -316,3 +316,37 @@ def test_augment_matrices() -> None:
             ]
         ),
     )
+
+
+@pytest.mark.parametrize("n_points", [10, 30])
+@pytest.mark.parametrize("n_outputs", [1, 3])
+@pytest.mark.parametrize("n_covariates", [1, 2])
+def test_sample_smoke_test(n_points: int, n_covariates: int, n_outputs: int) -> None:
+    """This is the high-level sampling function, which is composed
+    out of the building blocks above.
+
+    TODO(Pawel): This is just a smoke test, more elaborate tests to follow.
+    """
+    observed = jnp.ones((n_points, n_outputs), dtype=int)
+    intercepts = jnp.zeros(n_outputs)
+    coefficients = jnp.zeros((n_outputs, n_covariates))
+    structure = jnp.ones_like(coefficients, dtype=int)
+    covariates = jnp.ones((n_points, n_covariates))
+    variances = jnp.ones(n_covariates)
+
+    new_intercepts, new_coefficients = pg.sample_intercepts_and_coefficients(
+        jax_key=random.PRNGKey(21),
+        numpy_rng=np.random.default_rng(10),
+        observed=observed,
+        intercepts=intercepts,
+        coefficients=coefficients,
+        structure=structure,
+        covariates=covariates,
+        variances=variances,
+        pseudoprior_variance=0.01,
+        intercept_prior_mean=0,
+        intercept_prior_variance=1.0,
+    )
+
+    assert intercepts.shape == new_intercepts.shape
+    assert coefficients.shape == new_coefficients.shape

--- a/tests/logistic/test_polyagamma.py
+++ b/tests/logistic/test_polyagamma.py
@@ -1,0 +1,102 @@
+import time
+
+import jax
+import jax.numpy as jnp
+from jax import random
+
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+import numpy as np
+import numpy.testing as nptest
+
+import pytest
+
+import jnotype.logistic._polyagamma as pg
+
+
+class JAXRNG:
+    def __init__(self, key: random.PRNGKeyArray) -> None:
+        self._key = key
+
+    @property
+    def key(self) -> random.PRNGKeyArray:
+        key, subkey = random.split(self._key)
+        self._key = key
+        return subkey
+
+
+@pytest.mark.parametrize("n_features", [1, 2])
+def test_sample_coefficients(
+    save_artifact,
+    tmp_path,
+    n_features: int,
+    seed: int = 30,
+    n_points: int = 5_500,
+    n_covariates: int = 3,
+    n_gibbs_steps: int = 1_000,
+) -> None:
+    key_dataset, key_sampling = random.split(random.PRNGKey(seed))
+
+    # Prepare the data set
+    rng_dataset = JAXRNG(key_dataset)
+
+    design_matrix = random.bernoulli(
+        rng_dataset.key, 0.5, shape=(n_points, n_covariates)
+    )
+    true_coefficients = 0.8 * jnp.power(
+        -1, random.bernoulli(rng_dataset.key, 0.5, shape=(n_features, n_covariates))
+    )
+    #   random.normal(rng_dataset.key, shape=(n_features, n_covariates))
+    logits = pg._calculate_logits(
+        coefficients=true_coefficients, covariates=design_matrix
+    )
+    observed = jnp.asarray(
+        random.bernoulli(rng_dataset.key, jax.nn.sigmoid(logits)), dtype=int
+    )
+
+    current_coefficients = jnp.zeros_like(true_coefficients)
+    all_samples = []
+    subkeys = random.split(key_sampling, n_gibbs_steps)
+    numpy_rng = np.random.default_rng(seed + 21)
+    t0 = time.time()
+
+    for subkey in subkeys:
+        current_coefficients = pg.sample_coefficients(
+            jax_key=subkey,
+            numpy_rng=numpy_rng,
+            observed=observed,
+            design_matrix=design_matrix,
+            coefficients_prior_mean=jnp.zeros_like(true_coefficients),
+            coefficients_prior_variance=2 * jnp.ones_like(true_coefficients),
+            coefficients=current_coefficients,
+        )
+        assert current_coefficients.shape == true_coefficients.shape
+        all_samples.append(current_coefficients)
+
+    delta_t = time.time() - t0
+
+    print(f"Speed: {n_gibbs_steps/delta_t:.2f} steps/second.")
+
+    burnin = n_gibbs_steps // 4
+    all_samples = jnp.asarray(all_samples)[burnin:, ...]
+
+    coefficients_mean = all_samples.mean(axis=0)
+    coefficients_std = all_samples.std(axis=0)
+
+    if save_artifact:
+        directory = tmp_path / "test_sample_coefficients"
+        directory.mkdir()
+        fig, axs = plt.subplots(1, 3)
+
+        sns.heatmap(true_coefficients, ax=axs[0], cmap="seismic")
+        sns.heatmap(coefficients_mean, ax=axs[1], cmap="seismic")
+        sns.heatmap(coefficients_std, ax=axs[2], cmap="seismic")
+        axs[0].set_title("True")
+        axs[1].set_title("Posterior mean")
+        axs[2].set_title("Posterior std")
+
+        fig.tight_layout()
+        fig.savefig(directory / "coefficient_matrix.pdf")
+
+    nptest.assert_allclose(true_coefficients, coefficients_mean, atol=0.1)

--- a/tests/logistic/test_polyagamma.py
+++ b/tests/logistic/test_polyagamma.py
@@ -27,7 +27,7 @@ class JAXRNG:
 
 
 @pytest.mark.parametrize("n_features", [1, 2])
-def test_sample_coefficients(
+def test_sample_coefficients_trivial_structure(
     save_artifact,
     tmp_path,
     n_features: int,
@@ -36,6 +36,9 @@ def test_sample_coefficients(
     n_covariates: int = 3,
     n_gibbs_steps: int = 1_000,
 ) -> None:
+    """This function tests the `sample_coefficients` function
+    assuming that the structure matrix has only 1s
+    (no sampling from pseudoprior)."""
     key_dataset, key_sampling = random.split(random.PRNGKey(seed))
 
     # Prepare the data set
@@ -49,7 +52,9 @@ def test_sample_coefficients(
     )
     #   random.normal(rng_dataset.key, shape=(n_features, n_covariates))
     logits = pg._calculate_logits(
-        coefficients=true_coefficients, covariates=design_matrix
+        coefficients=true_coefficients,
+        covariates=design_matrix,
+        structure=jnp.ones_like(true_coefficients),
     )
     observed = jnp.asarray(
         random.bernoulli(rng_dataset.key, jax.nn.sigmoid(logits)), dtype=int
@@ -70,6 +75,7 @@ def test_sample_coefficients(
             coefficients_prior_mean=jnp.zeros_like(true_coefficients),
             coefficients_prior_variance=2 * jnp.ones_like(true_coefficients),
             coefficients=current_coefficients,
+            structure=jnp.ones_like(true_coefficients),
         )
         assert current_coefficients.shape == true_coefficients.shape
         all_samples.append(current_coefficients)

--- a/tests/logistic/test_polyagamma.py
+++ b/tests/logistic/test_polyagamma.py
@@ -50,7 +50,6 @@ def test_sample_coefficients_trivial_structure(
     true_coefficients = 0.8 * jnp.power(
         -1, random.bernoulli(rng_dataset.key, 0.5, shape=(n_features, n_covariates))
     )
-    #   random.normal(rng_dataset.key, shape=(n_features, n_covariates))
     logits = pg._calculate_logits(
         coefficients=true_coefficients,
         covariates=design_matrix,
@@ -108,7 +107,118 @@ def test_sample_coefficients_trivial_structure(
     nptest.assert_allclose(true_coefficients, coefficients_mean, atol=0.1)
 
 
-def test_design_matrix_coding():
+def test_sample_coefficients_nontrivial_structure(
+    n_points: int = 3_000,
+    n_gibbs_steps: int = 800,
+    seed: int = 21,
+) -> None:
+    """In this unit test we `sample_coefficients` but have some entries
+    in the structure matrix set to 0.
+    Hence, they should be sampled from the (pseudo)prior,
+    rather than the posterior.
+
+    Let's try 2 covariates and 3 outputs.
+    """
+    n_covariates = 2
+    true_coefficients = jnp.asarray(
+        [
+            [1.0, 1e9],
+            [1e10, -2.0],
+            [2e9, 4e9],
+        ]
+    )
+    # These e9 can't be identified
+    # and will be sampled just from the prior
+    structure = jnp.asarray(
+        [
+            [1, 0],
+            [0, 1],
+            [0, 0],
+        ]
+    )
+
+    key_dataset, key_sampling = random.split(random.PRNGKey(seed))
+
+    # Prepare the data set
+    rng_dataset = JAXRNG(key_dataset)
+    design_matrix = random.bernoulli(
+        rng_dataset.key, 0.5, shape=(n_points, n_covariates)
+    )
+    logits = pg._calculate_logits(
+        coefficients=true_coefficients,
+        covariates=design_matrix,
+        structure=structure,
+    )
+    observed = jnp.asarray(
+        random.bernoulli(rng_dataset.key, jax.nn.sigmoid(logits)), dtype=int
+    )
+
+    prior_mean = jnp.asarray(
+        [
+            [0.5, 10.0],
+            [20.0, -1.5],
+            [30.0, 40.0],
+        ]
+    )
+
+    prior_variance = jnp.asarray(
+        [[0.6, 0.02**2], [0.03**2, 0.5], [0.04**2, 0.05**2]]
+    )
+
+    current_coefficients = jnp.zeros_like(true_coefficients)
+
+    all_samples = []
+    subkeys = random.split(key_sampling, n_gibbs_steps)
+    numpy_rng = np.random.default_rng(seed + 152)
+    t0 = time.time()
+
+    for subkey in subkeys:
+        current_coefficients = pg.sample_coefficients(
+            jax_key=subkey,
+            numpy_rng=numpy_rng,
+            observed=observed,
+            design_matrix=design_matrix,
+            coefficients_prior_mean=prior_mean,
+            coefficients_prior_variance=prior_variance,
+            coefficients=current_coefficients,
+            structure=structure,
+        )
+        assert current_coefficients.shape == true_coefficients.shape
+        all_samples.append(current_coefficients)
+
+    delta_t = time.time() - t0
+
+    print(f"Speed: {n_gibbs_steps/delta_t:.2f} steps/second.")
+
+    burnin = n_gibbs_steps // 4
+    all_samples = jnp.asarray(all_samples)[burnin:, ...]
+
+    coefficients_mean = all_samples.mean(axis=0)
+    coefficients_std = all_samples.std(axis=0)
+
+    # What we expect: well-determined terms
+    # are close to their true values,
+    # non-determined values have means of their priors
+    wanted_mean = jnp.asarray(
+        [
+            [1.0, 10.0],
+            [20.0, -2.0],
+            [30.0, 40.0],
+        ]
+    )
+    nptest.assert_allclose(coefficients_mean, wanted_mean, atol=0.1)
+
+    # For non-determined values we also know that the standard deviation
+    # should be the one of the prior
+    assert coefficients_std[0, 1] == pytest.approx(0.02, rel=0.1)
+    assert coefficients_std[1, 0] == pytest.approx(0.03, rel=0.1)
+    assert coefficients_std[2, 0] == pytest.approx(0.04, rel=0.1)
+    assert coefficients_std[2, 1] == pytest.approx(0.05, rel=0.1)
+
+    # assert False, f"\n--- COEFFICIENTS: ---\n{coefficients_mean}\n{coefficients_std}"
+
+
+def test_augment_matrices() -> None:
     """Tests whether design matrix augmentation works properly.
 
     We have n=5 points with k=2 covariates each and three outputs f=3.


### PR DESCRIPTION
This PR adds sampling the coefficients (and intercepts) in the logistic regression. This leverages a mix of JAX samplers and the Pólya-Gamma sampler from the [polyagamma](https://pypi.org/project/polyagamma/) packages.