### PR TITLE
A prototype of the sampler for two-layer Bayesian pyramid and generic utilities for Gibbs sampling

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -68,7 +68,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def save_artifact(request):
+def save_artifact(request) -> bool:
     """Boolean fixture representing a CLI flag.
 
     True if generated artifacts should be saved, False if not."""

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,10 @@ import dataclasses
 
 import pytest
 
+import matplotlib
+
+matplotlib.use("Agg")
+
 
 @dataclasses.dataclass
 class TurnOnTestSuiteArgument:

--- a/examples/bernoulli_mixture_model.qmd
+++ b/examples/bernoulli_mixture_model.qmd
@@ -126,14 +126,23 @@ shrinkage_amount = 0.05
 
 key, subkey = jax.random.split(key)
 
-samples = jt.bmm.gibbs_sampler(
-    key=subkey,
+list_dataset = jt.sampling.ListDataset(
+    thinning=5,
+    dimensions=jt.bmm.BernoulliMixtureGibbsSampler.dimensions(),
+)
+
+gibbs_sampler = jt.bmm.BernoulliMixtureGibbsSampler(
+    datasets=[dataset],
     observed_data=input_data,
     dirichlet_prior=jnp.full(n_clusters_upper, shrinkage_amount),
-    thinning=5,
-    n_samples=500,
+    warmup=2000,
+    steps=3000,
     verbose=True,
 )
+
+gibbs_sampler.run()
+
+samples = list_dataset.dataset
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ whitelist-regex = []
 color = true
 
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.pyright]
 include = ["src", "tests"]
 exclude = ["**/node_modules",

--- a/src/jnotype/__init__.py
+++ b/src/jnotype/__init__.py
@@ -1,8 +1,10 @@
 """Exploratory analysis of binary data."""
 import jnotype.bmm as bmm
 import jnotype.datasets as datasets
+import jnotype.sampling as sampling
 
 __all__ = [
     "bmm",
     "datasets",
+    "sampling",
 ]

--- a/src/jnotype/_utils.py
+++ b/src/jnotype/_utils.py
@@ -1,0 +1,39 @@
+"""Generic utilities.
+
+This file should be as small as possible.
+Appearing themes should be refactored and placed
+into separate modules."""
+import jax
+
+
+class JAXRNG:
+    """JAX stateful random number generator.
+
+    Example:
+      key = jax.random.PRNGKey(5)
+      rng = JAXRNG(key)
+      a = jax.random.bernoulli(rng.key, shape=(10,))
+      b = jax.random.bernoulli(rng.key, shape=(10,))
+    """
+
+    def __init__(self, key: jax.random.PRNGKeyArray) -> None:
+        """
+        Args:
+            key: initialization key
+        """
+        self._key = key
+
+    @property
+    def key(self) -> jax.random.PRNGKeyArray:
+        """Generates a new key."""
+        key, subkey = jax.random.split(self._key)
+        self._key = key
+        return subkey
+
+    def __repr__(self) -> str:
+        """Used by the repr() method."""
+        return f"{type(self).__name__}(key={self._key})"
+
+    def __str__(self) -> str:
+        """Used by the str() method."""
+        return repr(self)

--- a/src/jnotype/bmm/__init__.py
+++ b/src/jnotype/bmm/__init__.py
@@ -1,18 +1,18 @@
 """Bernoulli Mixture Model."""
 from jnotype.bmm._em import expectation_maximization
 from jnotype.bmm._gibbs import (
-    gibbs_sampler,
     sample_mixing,
     sample_cluster_labels,
     sample_cluster_proportions,
+    BernoulliMixtureGibbsSampler,
 )
 from jnotype.bmm._gibbs import single_sampling_step as sample_bmm
 
 __all__ = [
     "expectation_maximization",
-    "gibbs_sampler",
     "sample_mixing",
     "sample_cluster_labels",
     "sample_cluster_proportions",
     "sample_bmm",
+    "BernoulliMixtureGibbsSampler",
 ]

--- a/src/jnotype/bmm/__init__.py
+++ b/src/jnotype/bmm/__init__.py
@@ -1,8 +1,18 @@
 """Bernoulli Mixture Model."""
 from jnotype.bmm._em import expectation_maximization
-from jnotype.bmm._gibbs import gibbs_sampler
+from jnotype.bmm._gibbs import (
+    gibbs_sampler,
+    sample_mixing,
+    sample_cluster_labels,
+    sample_cluster_proportions,
+)
+from jnotype.bmm._gibbs import single_sampling_step as sample_bmm
 
 __all__ = [
     "expectation_maximization",
     "gibbs_sampler",
+    "sample_mixing",
+    "sample_cluster_labels",
+    "sample_cluster_proportions",
+    "sample_bmm",
 ]

--- a/src/jnotype/bmm/_gibbs.py
+++ b/src/jnotype/bmm/_gibbs.py
@@ -1,5 +1,4 @@
 """Sampling cluster labels and proportions."""
-import time
 from typing import Optional, Sequence
 
 import jax
@@ -8,8 +7,6 @@ import jax.numpy as jnp
 from jax import random
 from jaxtyping import Array, Float, Int
 
-import tqdm
-import xarray as xr
 
 import jnotype.sampling as js
 from jnotype.sampling._chunker import DatasetInterface
@@ -209,9 +206,9 @@ class BernoulliMixtureGibbsSampler(js.AbstractGibbsSampler):
     def __init__(
         self,
         datasets: Sequence[DatasetInterface],
-        observed_data,
-        dirichlet_prior,
-        beta_prior,
+        observed_data: Int[Array, "observation feature"],
+        dirichlet_prior: Float[Array, " cluster"],
+        beta_prior: tuple[float, float] = (1.0, 1.0),
         *,
         jax_rng_key: Optional[jax.random.PRNGKeyArray] = None,
         warmup: int = 2000,
@@ -220,7 +217,10 @@ class BernoulliMixtureGibbsSampler(js.AbstractGibbsSampler):
     ) -> None:
         """
         Args:
-            TODO(Pawel): add descriptions and shapes
+          observed_data: observed data, shape (n_points, n_features)
+          dirichlet_prior: Dirichlet prior weights
+            on the cluster proportions, shape (n_clusters,)
+          beta_prior: beta prior weights on the mixing matrix entries
         """
         super().__init__(datasets, warmup=warmup, steps=steps, verbose=verbose)
 
@@ -231,8 +231,8 @@ class BernoulliMixtureGibbsSampler(js.AbstractGibbsSampler):
         self._dirichlet_prior = dirichlet_prior
         self._beta_prior = beta_prior
 
-    @property
-    def dimensions(self) -> dict:
+    @classmethod
+    def dimensions(cls) -> dict:
         """Named dimensions of each sample."""
         return {
             "labels": ["observation"],
@@ -283,164 +283,3 @@ class BernoulliMixtureGibbsSampler(js.AbstractGibbsSampler):
             "proportions": proportions,
             "mixing": mixing,
         }
-
-
-def _log(msg: str) -> None:
-    """TODO(Pawel): Replace with a logger."""
-    print(msg)
-
-
-def _init_params(
-    key: random.PRNGKeyArray,
-    dirichlet_prior: Float[Array, " B"],
-    beta_prior: tuple[float, float],
-    n_features: int,
-    proportions: Optional[Float[Array, " B"]],
-    mixing: Optional[Float[Array, "K B"]],
-) -> tuple[Float[Array, " B"], Float[Array, "K B"],]:
-    """Samples initial values for the parameters if they have not been defined."""
-    key_prop, key_mixing = random.split(key)
-
-    n_clusters = dirichlet_prior.shape[0]
-
-    sampled_proportions = random.dirichlet(key_prop, dirichlet_prior)
-    sampled_mixing = random.beta(
-        key_mixing, beta_prior[0], beta_prior[1], shape=(n_features, n_clusters)
-    )
-
-    assert sampled_proportions.shape == (n_clusters,)
-    assert sampled_mixing.shape == (n_features, n_clusters)
-
-    proportions = sampled_proportions if proportions is None else proportions
-    mixing = sampled_mixing if mixing is None else mixing
-
-    assert proportions.shape == (n_clusters,)
-    assert mixing.shape == (n_features, n_clusters)
-
-    return proportions, mixing
-
-
-def _map_storage(dct: dict) -> dict:
-    """Casts to JAX NumPy arrays the values in the dictionary
-    storing a list of samples."""
-    return {key: jnp.asarray(val) for key, val in dct.items()}
-
-
-def gibbs_sampler(
-    *,
-    key: random.PRNGKeyArray,
-    observed_data: Int[Array, "N K"],
-    dirichlet_prior: Float[Array, " B"],
-    beta_prior: tuple[float, float] = (1.0, 1.0),
-    n_samples: int = 5_000,
-    thinning: int = 10,
-    burnin: int = 1_000,
-    proportions: Optional[Float[Array, " B"]] = None,
-    mixing: Optional[Float[Array, "K B"]] = None,
-    verbose: bool = False,
-) -> xr.Dataset:
-    """Gibbs sampler for Bernoulli mixture model.
-
-    Args:
-        key: JAX random key
-        observed_data: observed data, shape (n_points, n_features)
-        dirichlet_prior: Dirichlet prior weights
-          on the cluster proportions, shape (n_clusters,)
-        beta_prior: beta prior weights on the mixing matrix entries
-        n_samples: number of samples to draw
-        thinning: we save a sample every `thinning` steps
-        burnin: number of warm-up steps. These draws are not saved.
-        verbose: whether to log progress
-        proportions: initial starting point for the cluster proportions
-          P(Z). If None, they will be sampled from the prior
-        mixing: initial starting point for the mixing matrix. If None,
-          it will be sampled from the prior
-
-    Returns:
-        xarray's `Dataset` with samples from the posterior
-        TODO(Pawel): Add more elaborate description
-    """
-    key_init, key_burnin, key_sampling = random.split(key, 3)
-
-    proportions, mixing = _init_params(
-        key=key_init,
-        dirichlet_prior=dirichlet_prior,
-        beta_prior=beta_prior,
-        proportions=proportions,
-        mixing=mixing,
-        n_features=observed_data.shape[1],
-    )
-
-    if verbose:
-        _log("Starting the burn-in phase sampling...")
-
-    # Run burn in samples
-    for key in random.split(key_burnin, burnin):
-        _, proportions, mixing = single_sampling_step(
-            key=key,
-            observed_data=observed_data,
-            proportions=proportions,
-            mixing=mixing,
-            dirichlet_prior=dirichlet_prior,
-            beta_prior=beta_prior,
-        )
-
-    if verbose:
-        _log("Burn-in phase finished. Starting proper sampling...")
-
-    t0 = time.time()
-
-    n_steps = thinning * n_samples
-    keys = random.split(key_sampling, n_steps)
-
-    storage = {
-        "labels": [],
-        "proportions": [],
-        "mixing": [],
-    }
-
-    for step, key in tqdm.tqdm(
-        enumerate(keys, 1), total=len(keys), disable=not verbose
-    ):
-        labels, proportions, mixing = single_sampling_step(
-            key=key,
-            observed_data=observed_data,
-            proportions=proportions,
-            mixing=mixing,
-            dirichlet_prior=dirichlet_prior,
-            beta_prior=beta_prior,
-        )
-
-        # Save samples every `thinning` steps
-        if step % thinning == 0:
-            storage["labels"].append(labels)
-            storage["proportions"].append(proportions)
-            storage["mixing"].append(mixing)
-
-    storage = _map_storage(storage)
-    dataset = xr.Dataset(
-        {
-            "labels": (["sample", "observation"], storage["labels"]),
-            "proportions": (["sample", "cluster"], storage["proportions"]),
-            "mixing": (["sample", "feature", "cluster"], storage["mixing"]),
-        },
-        coords={
-            "sample": (["sample"], jnp.arange(len(storage["labels"]))),
-            "observation": (["observation"], jnp.arange(observed_data.shape[0])),
-            "cluster": (["cluster"], jnp.arange(dirichlet_prior.shape[0])),
-            "feature": (["feature"], jnp.arange(observed_data.shape[1])),
-        },
-        attrs={
-            "description": "Draws from the posterior distribution "
-            "of Bernoulli Mixture Model using Gibbs sampler.",
-            "burnin": burnin,
-            "thinning": thinning,
-            "n_sampling_steps": n_steps,
-            "n_samples": len(storage["labels"]),
-            "beta_prior": beta_prior,
-            "dirichlet_prior": dirichlet_prior,
-            "time": time.time() - t0,
-        },
-    )
-
-    return dataset

--- a/src/jnotype/logistic/__init__.py
+++ b/src/jnotype/logistic/__init__.py
@@ -1,1 +1,12 @@
 """Submodule implementing (sparse) logistic regression."""
+
+from jnotype.logistic._binary_latent import sample_binary_codes
+from jnotype.logistic._polyagamma import sample_intercepts_and_coefficients
+from jnotype.logistic._structure import sample_structure, sample_gamma
+
+__all__ = [
+    "sample_structure",
+    "sample_gamma",
+    "sample_binary_codes",
+    "sample_intercepts_and_coefficients",
+]

--- a/src/jnotype/logistic/_binary_latent.py
+++ b/src/jnotype/logistic/_binary_latent.py
@@ -1,4 +1,6 @@
 """Sample binary latent variables."""
+from functools import partial
+
 import jax
 import jax.numpy as jnp
 from jax import random
@@ -8,6 +10,7 @@ from jnotype.logistic.logreg import calculate_loglikelihood_matrix_from_variable
 from jnotype.logistic._structure import _softmax_p1
 
 
+@partial(jax.jit, static_argnames="n_binary_codes")
 def sample_binary_codes(
     *,
     key: random.PRNGKeyArray,

--- a/src/jnotype/logistic/_polyagamma.py
+++ b/src/jnotype/logistic/_polyagamma.py
@@ -210,6 +210,7 @@ def _augment_matrices(
 
 
 def sample_intercepts_and_coefficients(
+    *,
     jax_key: random.PRNGKeyArray,
     numpy_rng: np.random.Generator,
     observed: Int[Array, "points features"],

--- a/src/jnotype/logistic/_polyagamma.py
+++ b/src/jnotype/logistic/_polyagamma.py
@@ -46,6 +46,9 @@ def _sample_coefficients(
         omega,
         covariates,
         structure,
+        # Empirically this seems to be giving 2x speedup
+        # over not specifying
+        optimize="greedy",
     )
     precision_matrices: Float[Array, "features covariates covariates"] = jax.vmap(
         jnp.diag

--- a/src/jnotype/logistic/_structure.py
+++ b/src/jnotype/logistic/_structure.py
@@ -38,6 +38,7 @@ def _logpdf_gaussian(
     return -0.5 * jnp.square(xs) / variance - log_stds
 
 
+@jax.jit
 def sample_structure(
     *,
     key: random.PRNGKeyArray,
@@ -48,7 +49,7 @@ def sample_structure(
     observed: Int[Array, "points features"],
     variances: Float[Array, " covs"],
     pseudoprior_variance: float,
-    gamma: float,
+    gamma: Union[float, Float[Array, ""]],
 ) -> Int[Array, "features covs"]:
     """We have `covs` covariates (predictors) used
     to model `observed` points with `features` features each
@@ -155,6 +156,7 @@ def sample_structure(
     return jax.lax.fori_loop(0, K, body_fun, structure)
 
 
+@jax.jit
 def sample_gamma(
     key: random.PRNGKeyArray,
     structure: Int[Array, "G K"],

--- a/src/jnotype/pyramids/__init__.py
+++ b/src/jnotype/pyramids/__init__.py
@@ -17,6 +17,7 @@ from jnotype.logistic import (
     sample_binary_codes,
     sample_intercepts_and_coefficients,
 )
+from jnotype._utils import JAXRNG
 from jnotype._variance import sample_variances
 
 
@@ -49,7 +50,9 @@ def single_sampling_step(
     variances_prior_scale: float = 1.0,
     mixing_beta_prior: tuple[float, float] = (1.0, 1.0),
 ) -> dict:
-    t0 = time.time()
+    """Single sampling step of two-layer Bayesian pyramid.
+    To be refactored."""
+    time.time()
 
     # --- Sample the sparse logistic regression layer ---
     # Sample intercepts and coefficients
@@ -67,7 +70,7 @@ def single_sampling_step(
         intercept_prior_variance=intercept_prior_variance,
         observed=observed,
     )
-    t1 = time.time()
+    time.time()
     # print(f"Sampling intercepts and coefs: {t1-t0:.2f}")
 
     # Sample structure and the sparsity
@@ -90,7 +93,7 @@ def single_sampling_step(
         prior_b=gamma_prior_b,
     )
 
-    t2 = time.time()
+    time.time()
     # print(f"Sampling structure: {t2-t1:.2f}")
 
     # Sample prior variances for coefficients
@@ -103,7 +106,7 @@ def single_sampling_step(
         prior_scale=variances_prior_scale,
     )
 
-    t3 = time.time()
+    time.time()
     # print(f"Sampling variances: {t3-t2:.2f}")
 
     # Sample binary latent variables
@@ -120,7 +123,7 @@ def single_sampling_step(
         labels_to_codes=mixing,
     )
 
-    t4 = time.time()
+    time.time()
     # print(f"Sampling binary latent variables: {t4-t3:.2f}")
 
     # --- Sample the Bernoulli mixture model layer ---
@@ -135,7 +138,7 @@ def single_sampling_step(
         beta_prior=mixing_beta_prior,
     )
 
-    t5 = time.time()
+    time.time()
     # print(f"Sampling BMM: {t5-t4:.2f}")
 
     return {
@@ -149,17 +152,6 @@ def single_sampling_step(
         "proportions": proportions,
         "mixing": mixing,
     }
-
-
-class JAXRNG:
-    def __init__(self, key: random.PRNGKeyArray) -> None:
-        self._key = key
-
-    @property
-    def key(self) -> random.PRNGKeyArray:
-        key, subkey = random.split(self._key)
-        self._key = key
-        return subkey
 
 
 def _initialize(

--- a/src/jnotype/pyramids/__init__.py
+++ b/src/jnotype/pyramids/__init__.py
@@ -1,0 +1,273 @@
+"""Gibbs sampler for Bayesian pyramids."""
+import time
+
+import numpy as np
+import tqdm
+
+import jax.numpy as jnp
+from jax import random
+
+from jaxtyping import Array, Float, Int
+
+# Import sampling steps
+from jnotype.bmm import sample_bmm
+from jnotype.logistic import (
+    sample_gamma,
+    sample_structure,
+    sample_binary_codes,
+    sample_intercepts_and_coefficients,
+)
+from jnotype._variance import sample_variances
+
+
+def single_sampling_step(
+    *,
+    # Auxiliary: random keys, static specification
+    jax_key: random.PRNGKeyArray,
+    numpy_rng: np.random.Generator,
+    n_binary_codes: int,
+    # Observed values
+    observed: Int[Array, "points observed"],
+    # Sampled variables
+    intercepts: Float[Array, " observed"],
+    coefficients: Float[Array, "observed covariates"],
+    structure: Int[Array, "observed covariates"],
+    covariates: Float[Array, "points covariates"],
+    variances: Float[Array, " covariates"],
+    gamma: Float[Array, ""],
+    cluster_labels: Int[Array, " points"],
+    mixing: Float[Array, "n_binary_codes n_clusters"],
+    proportions: Float[Array, " n_clusters"],
+    # Priors
+    dirichlet_prior: Float[Array, " n_clusters"],
+    pseudoprior_variance: float = 0.01,
+    intercept_prior_mean: float = 0.0,
+    intercept_prior_variance: float = 1.0,
+    gamma_prior_a: float = 1.0,
+    gamma_prior_b: float = 1.0,
+    variances_prior_shape: float = 2.0,
+    variances_prior_scale: float = 1.0,
+    mixing_beta_prior: tuple[float, float] = (1.0, 1.0),
+) -> dict:
+    t0 = time.time()
+
+    # --- Sample the sparse logistic regression layer ---
+    # Sample intercepts and coefficients
+    key, subkey = random.split(jax_key)
+    intercepts, coefficients = sample_intercepts_and_coefficients(
+        jax_key=subkey,
+        numpy_rng=numpy_rng,
+        intercepts=intercepts,
+        coefficients=coefficients,
+        structure=structure,
+        covariates=covariates,
+        variances=variances,
+        pseudoprior_variance=pseudoprior_variance,
+        intercept_prior_mean=intercept_prior_mean,
+        intercept_prior_variance=intercept_prior_variance,
+        observed=observed,
+    )
+    t1 = time.time()
+    print(f"Sampling intercepts and coefs: {t1-t0:.2f}")
+
+    # Sample structure and the sparsity
+    key, subkey_structure, subkey_gamma = random.split(key, 3)
+    structure = sample_structure(
+        key=subkey_structure,
+        intercepts=intercepts,
+        coefficients=coefficients,
+        structure=structure,
+        covariates=covariates,
+        observed=observed,
+        variances=variances,
+        pseudoprior_variance=pseudoprior_variance,
+        gamma=gamma,
+    )
+    gamma = sample_gamma(
+        key=subkey_gamma,
+        structure=structure,
+        prior_a=gamma_prior_a,
+        prior_b=gamma_prior_b,
+    )
+
+    t2 = time.time()
+    print(f"Sampling structure: {t2-t1:.2f}")
+
+    # Sample prior variances for coefficients
+    key, subkey = random.split(key)
+    variances = sample_variances(
+        key=subkey,
+        values=coefficients,
+        mask=structure,
+        prior_shape=variances_prior_shape,
+        prior_scale=variances_prior_scale,
+    )
+
+    t3 = time.time()
+    print(f"Sampling variances: {t3-t2:.2f}")
+
+    # Sample binary latent variables
+    key, subkey = random.split(key)
+    covariates = sample_binary_codes(
+        key=subkey,
+        intercepts=intercepts,
+        coefficients=coefficients,
+        structure=structure,
+        covariates=covariates,
+        observed=observed,
+        n_binary_codes=n_binary_codes,
+        labels=cluster_labels,
+        labels_to_codes=mixing,
+    )
+
+    t4 = time.time()
+    print(f"Sampling binary latent variables: {t4-t3:.2f}")
+
+    # --- Sample the Bernoulli mixture model layer ---
+    key, subkey = random.split(key)
+    cluster_labels, proportions, mixing = sample_bmm(
+        key=subkey,
+        # Bernoulli mixture model sees the binary latent codes
+        observed_data=covariates[:, :n_binary_codes],
+        proportions=proportions,
+        mixing=mixing,
+        dirichlet_prior=dirichlet_prior,
+        beta_prior=mixing_beta_prior,
+    )
+
+    t5 = time.time()
+    print(f"Sampling BMM: {t5-t4:.2f}")
+
+    return {
+        "intercepts": intercepts,
+        "coefficients": coefficients,
+        "structure": structure,
+        "gamma": gamma,
+        "variances": variances,
+        "covariates": covariates,
+        "cluster_labels": cluster_labels,
+        "proportions": proportions,
+        "mixing": mixing,
+    }
+
+
+class JAXRNG:
+    def __init__(self, key: random.PRNGKeyArray) -> None:
+        self._key = key
+
+    @property
+    def key(self) -> random.PRNGKeyArray:
+        key, subkey = random.split(self._key)
+        self._key = key
+        return subkey
+
+
+def _initialize(
+    key: random.PRNGKeyArray,
+    n_clusters: int,
+    n_points: int,
+    n_outputs: int,
+    n_covariates: int,
+    n_binary_codes: int,
+):
+    rng = JAXRNG(key)
+    return {
+        "intercepts": random.normal(rng.key, shape=(n_outputs,)),
+        "coefficients": random.normal(rng.key, shape=(n_outputs, n_covariates)),
+        "structure": random.bernoulli(rng.key, p=0.1, shape=(n_outputs, n_covariates)),
+        "gamma": jnp.asarray(0.1),
+        "variances": jnp.ones(n_covariates),
+        "covariates": jnp.asarray(
+            random.bernoulli(rng.key, p=0.5, shape=(n_points, n_covariates)),
+            dtype=float,
+        ),
+        "cluster_labels": random.categorical(
+            rng.key, logits=jnp.zeros(n_clusters), shape=(n_points,)
+        ),
+        "proportions": jnp.full(fill_value=1 / n_clusters, shape=(n_clusters,)),
+        "mixing": random.beta(rng.key, a=1, b=1, shape=(n_binary_codes, n_clusters)),
+    }
+
+
+def do_steps(
+    n_steps: int = 100,
+    n_clusters: int = 4,
+    n_points: int = 8_000,
+    n_outputs: int = 200,
+    n_covariates: int = 10,
+    n_binary_codes: int = 5,
+    burnin: int = 2,
+):
+    """Temporary method, will be removed/refactored into unit test.
+
+    TODO(Pawel): refactor/remove.
+    """
+
+    rng = np.random.default_rng(32)
+    key_init, key_observed, *keys = random.split(random.PRNGKey(12), n_steps + 2)
+    sample = _initialize(
+        key=key_init,
+        n_binary_codes=n_binary_codes,
+        n_clusters=n_clusters,
+        n_points=n_points,
+        n_outputs=n_outputs,
+        n_covariates=n_covariates,
+    )
+
+    observed = random.bernoulli(key_observed, p=0.1, shape=(n_points, n_outputs))
+
+    for _ in range(burnin):
+        sample = single_sampling_step(
+            jax_key=random.PRNGKey(10),  # TODO(Pawel): This is wrong
+            numpy_rng=rng,
+            n_binary_codes=n_binary_codes,
+            observed=observed,
+            intercepts=sample["intercepts"],
+            coefficients=sample["coefficients"],
+            structure=sample["structure"],
+            covariates=sample["covariates"],
+            variances=sample["variances"],
+            gamma=sample["gamma"],
+            cluster_labels=sample["cluster_labels"],
+            mixing=sample["mixing"],
+            proportions=sample["proportions"],
+            dirichlet_prior=jnp.ones(n_clusters),
+        )
+
+    all_samples = []
+    thinning = 10
+
+    t0 = time.time()
+    for i, key in tqdm.tqdm(enumerate(keys, 1), total=len(keys)):
+        sample = single_sampling_step(
+            jax_key=key,
+            numpy_rng=rng,
+            n_binary_codes=n_binary_codes,
+            observed=observed,
+            intercepts=sample["intercepts"],
+            coefficients=sample["coefficients"],
+            structure=sample["structure"],
+            covariates=sample["covariates"],
+            variances=sample["variances"],
+            gamma=sample["gamma"],
+            cluster_labels=sample["cluster_labels"],
+            mixing=sample["mixing"],
+            proportions=sample["proportions"],
+            dirichlet_prior=jnp.ones(n_clusters),
+        )
+
+        if i % thinning == 0:
+            all_samples.append(sample)
+
+    t1 = time.time()
+    delta_t = t1 - t0
+
+    print(f"Executed {len(keys)} steps in {delta_t:.2f} seconds")
+    print(f"Iteration speed: {len(keys) / delta_t:.2f} steps/second.")
+
+    print(f"Collected {len(all_samples)} in {delta_t:.2f} seconds.")
+    print(f"Sampling speed: {len(all_samples) / delta_t:.2f} samples/seconds.")
+
+
+if __name__ == "__main__":
+    do_steps()

--- a/src/jnotype/pyramids/__init__.py
+++ b/src/jnotype/pyramids/__init__.py
@@ -68,7 +68,7 @@ def single_sampling_step(
         observed=observed,
     )
     t1 = time.time()
-    print(f"Sampling intercepts and coefs: {t1-t0:.2f}")
+    # print(f"Sampling intercepts and coefs: {t1-t0:.2f}")
 
     # Sample structure and the sparsity
     key, subkey_structure, subkey_gamma = random.split(key, 3)
@@ -91,7 +91,7 @@ def single_sampling_step(
     )
 
     t2 = time.time()
-    print(f"Sampling structure: {t2-t1:.2f}")
+    # print(f"Sampling structure: {t2-t1:.2f}")
 
     # Sample prior variances for coefficients
     key, subkey = random.split(key)
@@ -104,7 +104,7 @@ def single_sampling_step(
     )
 
     t3 = time.time()
-    print(f"Sampling variances: {t3-t2:.2f}")
+    # print(f"Sampling variances: {t3-t2:.2f}")
 
     # Sample binary latent variables
     key, subkey = random.split(key)
@@ -121,7 +121,7 @@ def single_sampling_step(
     )
 
     t4 = time.time()
-    print(f"Sampling binary latent variables: {t4-t3:.2f}")
+    # print(f"Sampling binary latent variables: {t4-t3:.2f}")
 
     # --- Sample the Bernoulli mixture model layer ---
     key, subkey = random.split(key)
@@ -136,7 +136,7 @@ def single_sampling_step(
     )
 
     t5 = time.time()
-    print(f"Sampling BMM: {t5-t4:.2f}")
+    # print(f"Sampling BMM: {t5-t4:.2f}")
 
     return {
         "intercepts": intercepts,
@@ -194,7 +194,7 @@ def do_steps(
     n_clusters: int = 4,
     n_points: int = 8_000,
     n_outputs: int = 200,
-    n_covariates: int = 10,
+    n_covariates: int = 20,
     n_binary_codes: int = 5,
     burnin: int = 2,
 ):

--- a/src/jnotype/sampling/__init__.py
+++ b/src/jnotype/sampling/__init__.py
@@ -1,1 +1,16 @@
 """Generic utilities for sampling."""
+from jnotype.sampling._chunker import (
+    DatasetInterface,
+    ListDataset,
+    XArrayChunkedDataset,
+    AbstractChunkedDataset,
+)
+from jnotype.sampling._sampler import AbstractGibbsSampler
+
+__all__ = [
+    "DatasetInterface",
+    "ListDataset",
+    "XArrayChunkedDataset",
+    "AbstractChunkedDataset",
+    "AbstractGibbsSampler",
+]

--- a/src/jnotype/sampling/__init__.py
+++ b/src/jnotype/sampling/__init__.py
@@ -1,0 +1,1 @@
+"""Generic utilities for sampling."""

--- a/src/jnotype/sampling/_chunker.py
+++ b/src/jnotype/sampling/_chunker.py
@@ -1,0 +1,187 @@
+"""Utilities for saving samples in chunks, to limit RAM usage."""
+import abc
+
+from datetime import datetime
+from typing import Optional, Union
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+
+class AbstractChunkedDataset(abc.ABC):
+    """Abstract base class for chunked data sets.
+
+    Usage:
+        `append_sample` adds a new sample to the data set
+
+    Note:
+        The data set is automatically saved to the disk every `buffer_size` samples.
+        We recommend running `save` method manually at the end of the sampling, so that
+        an incomplete buffer is also saved.
+    """
+
+    def __init__(
+        self,
+        directory: Union[str, Path],
+        buffer_size: int = 1_000,
+        thinning: Optional[int] = None,
+    ) -> None:
+        """
+        Args:
+            directory: where the chunks will be saved
+            buffer_size: controls how oftern the buffer will be saved to the disk
+            thinning: whether thinning should be used.
+                Set to `None` or 1 for no thinning (recommended)
+        """
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=False)
+        self.thinning: int = thinning or 1
+        self.buffer_size: int = buffer_size
+
+        self.iteration: int = 0
+        self.file_index: int = 1
+
+        self._buffer: list[dict] = []
+        # Sample index, shared across files, so that it's easier to concatenate them.
+        self._sample_index: list[int] = []
+        self._global_index: int = 1
+
+    @abc.abstractmethod
+    def _filename(self, file_index: int) -> str:
+        """A pure function generating file name from `file_index` provided."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _save_buffer(
+        self, buffer: list[dict], sample_index: list[int], filepath: Path
+    ) -> None:
+        """A pure function saving `buffer` and `sample_index` to `filepath`."""
+        raise NotImplementedError
+
+    def save(self) -> None:
+        """Can be used to manually save the buffer.
+
+        We recommend running it only once, at the end of the sampling.
+        """
+        if not len(self._buffer):
+            return
+
+        filepath = self.directory / self._filename(self.file_index)
+        self.file_index += 1
+
+        self._save_buffer(self._buffer, self._sample_index, filepath)
+        self._reset_buffer()
+
+    def _reset_buffer(self) -> None:
+        """Empties the buffer. This function is not pure."""
+        self._buffer = []
+        self._sample_index = []
+
+    def append_sample(self, sample: dict) -> None:
+        """Adds a new sample to the buffer."""
+        self.iteration += 1
+
+        if self.iteration % self.thinning == 0:
+            self._buffer.append(sample)
+            self._sample_index.append(self._global_index)
+            self._global_index += 1
+
+        if len(self._buffer) >= self.buffer_size:
+            self.save()
+
+
+class XArrayChunkedDataset(AbstractChunkedDataset):
+    """A chunked data set based on Xarray's Dataset utilities
+    and saving the samples to NetCDF format."""
+
+    def __init__(
+        self,
+        directory: Union[str, Path],
+        basic_dimensions: dict[str, Union[tuple[str, ...], list[str]]],
+        *,
+        buffer_size: int = 1000,
+        thinning: Optional[int] = None,
+        attrs: Optional[dict] = None,
+        coords: Optional[dict[str, np.ndarray]] = None,
+    ) -> None:
+        """
+        Args:
+            basic_dimensions: specify the dimensions of each item in the sample
+
+        Example:
+            If in one sample you have array "coordinates"
+              it can have shape ("dimension",).
+              Then you should specify {"coordinates": ["dimension"]}
+        """
+        # TODO(Pawel): Check for unspecified behaviour
+        #   when a sample is array(3.0), i.e., of shape (,)
+        super().__init__(
+            directory=directory, buffer_size=buffer_size, thinning=thinning
+        )
+
+        self._attrs = attrs or {}
+        self._coords = coords or {}
+        self._basic_dimensions = basic_dimensions
+
+    def _filename(self, file_index: int) -> str:
+        return f"{file_index:05}.nc"
+
+    def append_sample(self, sample: dict) -> None:
+        """Appends a new sample.
+
+        Raises:
+            KeyError, if the sample has different keys than declared
+        """
+        # Check if the keys are right
+        if self.iteration < 3 or self.iteration % 100 == 0:
+            if set(self._basic_dimensions.keys()) != set(sample.keys()):
+                msg = (
+                    f"Keys mismatch: {self._basic_dimensions.keys()} "
+                    f"!= {sample.keys()}."
+                )
+                raise KeyError(msg)
+
+        super().append_sample(sample)
+
+    @staticmethod
+    def _extract_from_buffer(buffer: list[dict], label: str) -> np.ndarray:
+        return np.asarray([item[label] for item in buffer])
+
+    def _coords_for_label(self, label: str) -> list[str]:
+        if label not in self._basic_dimensions:
+            raise ValueError(f"Label {label} does not have dimensions assigned.")
+        return ["sample"] + list(self._basic_dimensions[label])
+
+    def _buffer_to_dataset(
+        self, buffer: list[dict], sample_index: list[int]
+    ) -> xr.Dataset:
+        attrs = {
+            "thinning": self.thinning,
+            "n_samples_in_batch": len(buffer),
+            "timestamp_save": datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
+        } | self._attrs
+
+        coords = {
+            "sample": np.asarray(sample_index),
+        } | self._coords
+
+        variables = {
+            label: (
+                self._coords_for_label(label),
+                self._extract_from_buffer(buffer=buffer, label=label),
+            )
+            for label in self._basic_dimensions.keys()
+        }
+
+        return xr.Dataset(
+            data_vars=variables,
+            coords=coords,
+            attrs=attrs,
+        )
+
+    def _save_buffer(
+        self, buffer: list[dict], sample_index: list[int], filepath: Path
+    ) -> None:
+        dataset = self._buffer_to_dataset(buffer, sample_index)
+        dataset.to_netcdf(filepath)

--- a/src/jnotype/sampling/_sampler.py
+++ b/src/jnotype/sampling/_sampler.py
@@ -37,8 +37,8 @@ class AbstractGibbsSampler(abc.ABC):
         self.steps = steps
         self.verbose = verbose
 
-    @abc.abstractproperty
-    def dimensions(self) -> dict:
+    @abc.abstractclassmethod
+    def dimensions(cls) -> dict:
         """Returns dictionary describing
         the dimensions, e.g.,:
         {

--- a/src/jnotype/sampling/_sampler.py
+++ b/src/jnotype/sampling/_sampler.py
@@ -1,0 +1,128 @@
+"""Generic Gibbs sampler."""
+import abc
+import logging
+import time
+from typing import Optional, Sequence
+
+import tqdm
+
+from jnotype.sampling._chunker import DatasetInterface
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AbstractGibbsSampler(abc.ABC):
+    """Abstract Gibbs sampler.
+
+    All children classes should implement:
+      dimensions: describes the sample and the shapes
+      new_sample: Markov chain transition to a new point
+
+    """
+
+    def __init__(
+        self,
+        datasets: Sequence[DatasetInterface],
+        *,
+        warmup: int = 2_000,
+        steps: int = 3_000,
+        verbose: bool = False,
+    ) -> None:
+        """
+        Args:
+            datasets: data sets storing the samples
+        """
+        self.datasets = list(datasets)
+        self.warmup = warmup
+        self.steps = steps
+        self.verbose = verbose
+
+    @abc.abstractproperty
+    def dimensions(self) -> dict:
+        """Returns dictionary describing
+        the dimensions, e.g.,:
+        {
+            "coeffs": ["n_outputs", "n_inputs"],
+            "intercepts": ["n_outputs"],
+        }
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def new_sample(self, sample: dict) -> dict:
+        """Transition to a new sample."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def initialise(self) -> dict:
+        """Initializes the sample."""
+        raise NotImplementedError
+
+    def _append(self, sample: dict) -> None:
+        """Appends the sample to all data sets."""
+        for dataset in self.datasets:
+            dataset.append_sample(sample)
+
+    def _end_run(self) -> None:
+        """Signalizes to all data sets that sampling
+        has finished."""
+        for dataset in self.datasets:
+            dataset.end()
+
+    def _init_sample(self, start: Optional[dict]) -> dict:
+        """Initialise first sample using `initialise` method
+        and overwriting the fields with `start`.
+
+        Raises:
+            KeyError, if there are fields in `start` which are not
+              in the sample from `initialise`
+        """
+        # Initialise first sample
+        sample = self.initialise()
+        start = start or {}
+        if not set(start.keys()).issubset(sample.keys()):
+            raise KeyError(
+                f"Init keys: {sample.keys()}. Tried to update with: {start.keys()}."
+            )
+        sample.update(start)
+
+        return sample
+
+    def run(self, start: Optional[dict] = None) -> None:
+        """Full Gibbs sampling run."""
+        # Initialise the sample
+        _LOGGER.info("Initialising the first sample...")
+        sample = self._init_sample(start)
+
+        # Warmup period
+        _LOGGER.info(f"Starting warmup period with {self.warmup} steps...")
+        t0 = time.time()
+
+        for _ in tqdm.tqdm(
+            range(self.warmup), total=self.warmup, disable=not self.verbose
+        ):
+            sample = self.new_sample(sample)
+
+        dt = time.time() - t0
+        _LOGGER.info(
+            f"Warmup finished in {dt:.1f} seconds "
+            f"({(self.warmup/dt):.1f} steps/s). "
+            f"Starting proper sampling..."
+        )
+
+        t1 = time.time()
+        for _ in tqdm.tqdm(
+            range(1, self.steps + 1), total=self.steps, disable=not self.verbose
+        ):
+            sample = self.new_sample(sample)
+            self._append(sample)
+
+        t2 = time.time()
+        dt = t2 - t1
+
+        _LOGGER.info(
+            f"Finished sampling in {dt:.1f} seconds." f"({self.steps/dt:.1f}) steps/s"
+        )
+
+        self._end_run()
+        _LOGGER.info(f"Run finished in {t2-t0:.1} seconds.")

--- a/tests/logistic/test_binary_latent.py
+++ b/tests/logistic/test_binary_latent.py
@@ -1,4 +1,5 @@
 import time
+from typing import cast
 
 import numpy as np
 import numpy.testing as nptest
@@ -126,6 +127,7 @@ def test_sample_binary_codes(
 
         # All covariates heatmap
         fig, axs = plt.subplots(1, 3)
+        fig = cast(plt.Figure, fig)
         sns.heatmap(
             inferred_mean - all_covariates,
             ax=axs[0],
@@ -146,6 +148,7 @@ def test_sample_binary_codes(
 
         # Binary codes heatmap
         fig, axs = plt.subplots(1, 3)
+        fig = cast(plt.Figure, fig)
         sns.heatmap(
             inferred_mean[:, :n_binary_codes] - true_codes,
             ax=axs[0],

--- a/tests/logistic/test_polyagamma.py
+++ b/tests/logistic/test_polyagamma.py
@@ -1,4 +1,5 @@
 import time
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -13,17 +14,7 @@ import numpy.testing as nptest
 import pytest
 
 import jnotype.logistic._polyagamma as pg
-
-
-class JAXRNG:
-    def __init__(self, key: random.PRNGKeyArray) -> None:
-        self._key = key
-
-    @property
-    def key(self) -> random.PRNGKeyArray:
-        key, subkey = random.split(self._key)
-        self._key = key
-        return subkey
+from jnotype._utils import JAXRNG
 
 
 @pytest.mark.parametrize("n_features", [1, 2])
@@ -93,6 +84,7 @@ def test_sample_coefficients_trivial_structure(
         directory = tmp_path / "test_sample_coefficients"
         directory.mkdir()
         fig, axs = plt.subplots(1, 3)
+        fig = cast(plt.Figure, fig)
 
         sns.heatmap(true_coefficients, ax=axs[0], cmap="seismic")
         sns.heatmap(coefficients_mean, ax=axs[1], cmap="seismic")

--- a/tests/logistic/test_structure.py
+++ b/tests/logistic/test_structure.py
@@ -1,4 +1,5 @@
 import time
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -119,6 +120,7 @@ def test_sample_structure(
         directory.mkdir()
 
         fig, axs = plt.subplots(1, 3)
+        fig = cast(plt.Figure, fig)
         sns.heatmap(
             posterior_mean - true_structure,
             ax=axs[0],

--- a/tests/logistic/test_structure.py
+++ b/tests/logistic/test_structure.py
@@ -1,3 +1,5 @@
+import time
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -6,7 +8,6 @@ from jax import random
 from jnotype.logistic.logreg import calculate_logits
 import jnotype.logistic._structure as _str
 
-import time
 import seaborn as sns
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
This PR started as the Gibbs sampler for a two-layer Bayesian pyramid. In the end:
  - We have an early prototype of the Gibbs sampler for the two-layer Bayesian pyramid.
  - Utilities for the Gibbs sampling, so that we can save the samples in batches.
  - I refactored the Bernoulli mixture model Gibbs sampler to use the new utilities.

### Tasks
- [x] Add the sampling step.
- [x] Wrap into a sampling loop (with initialization, `burnin` and `thinning` parameters, and producing `xarray.Dataset` in the end).
- [x] Add the simplest data set sampled according to this model and run Bayesian pyramid.

### Performance

For 8,000 data points, 10 covariates (5 binary codes, 5 other), and 4 clusters it results in 2.6 steps/second.
For 8,000 data points, 20 covariates (5 binary codes, 15 other), and 4 clusters it results in 1.4 steps/second.

In the latter case, one step is 0.7 seconds. Most things take zero time, sampling the structure matrix takes 0.05 second and the most expensive operation (0.6 seconds) is sampling the coefficients. Pólya-Gamma sampler takes 0.17-0.18 seconds and around 0.45-0.46 seconds is *spent on sampling the variables given the Pólya-Gamma variables*.

There's some potential in (a) using GPU, as JIT will do all linear algebra using XLA with CUDA support, (b) optimizing `jnp.einsum`.

Update:  in 55388ef9a951fa36481b6a4232d21deb243c2424 I set one `jnp.einsum` strategy to `"greedy"` and now most of the time is spent in the Pólya-Gamma sampler. Overall, we have ~2x speedup with 3.9 steps/second.