### PR TITLE
Add observed covariates to Bayesian pyramids

### DIFF
--- a/src/jnotype/logistic/__init__.py
+++ b/src/jnotype/logistic/__init__.py
@@ -2,11 +2,16 @@
 
 from jnotype.logistic._binary_latent import sample_binary_codes
 from jnotype.logistic._polyagamma import sample_intercepts_and_coefficients
-from jnotype.logistic._structure import sample_structure, sample_gamma
+from jnotype.logistic._structure import (
+    sample_structure,
+    sample_gamma,
+    sample_gamma_individual,
+)
 
 __all__ = [
     "sample_structure",
     "sample_gamma",
+    "sample_gamma_individual",
     "sample_binary_codes",
     "sample_intercepts_and_coefficients",
 ]

--- a/src/jnotype/logistic/_structure.py
+++ b/src/jnotype/logistic/_structure.py
@@ -173,3 +173,22 @@ def sample_gamma(
     posterior_b = prior_b + (n_all - n_successes)
 
     return random.beta(key, posterior_a, posterior_b)
+
+
+@jax.jit
+def sample_gamma_individual(
+    key: random.PRNGKeyArray,
+    structure: Int[Array, "G K"],
+    prior_a: Float[Array, " K"],
+    prior_b: Float[Array, " K"],
+) -> Float[Array, " K"]:
+    """Samples the sparsity basing on the structure matrix,
+    but for each covariate separately.
+    """
+    n_successes = jnp.sum(structure, axis=0)
+    n_all = structure.shape[0]
+
+    posterior_a = prior_a + n_successes
+    posterior_b = prior_b + (n_all - n_successes)
+
+    return random.beta(key, posterior_a, posterior_b)

--- a/src/jnotype/logistic/_structure.py
+++ b/src/jnotype/logistic/_structure.py
@@ -49,7 +49,7 @@ def sample_structure(
     observed: Int[Array, "points features"],
     variances: Float[Array, " covs"],
     pseudoprior_variance: float,
-    gamma: Union[float, Float[Array, ""]],
+    gamma: Float[Array, " covs"],
 ) -> Int[Array, "features covs"]:
     """We have `covs` covariates (predictors) used
     to model `observed` points with `features` features each
@@ -80,9 +80,9 @@ def sample_structure(
           part of the prior. However, we sample from pseudoprior,
           the coefficient is turned off and contribution to the likelihood
           is exactly zero)
-        gamma: probability of an individual entry to be turned on.
+        gamma: probability of an individual entry to be turned on for each covariate
           Controls the sparsity (values near 0 result in a prior to
-          be a very sparse matrix)
+          be a very sparse coefficient vectors for a given covariate)
     """
     K = coefficients.shape[-1]
     keys = jax.random.split(key, K)
@@ -141,8 +141,8 @@ def sample_structure(
         )
 
         # Finally, we have the prior on coefficients, controlled by gamma
-        log_prior0 = jnp.log1p(-gamma)  # This is log(1-gamma)
-        log_prior1 = jnp.log(gamma)
+        log_prior0 = jnp.log1p(-gamma[k])  # This is log(1-gamma[k])
+        log_prior1 = jnp.log(gamma[k])
 
         # Now we can calculate unnormalized posteriors. Both are shape (features,)
         log_p0 = log_likelihood0 + log_coef0 + log_prior0

--- a/src/jnotype/pyramids/_sampler_fixed.py
+++ b/src/jnotype/pyramids/_sampler_fixed.py
@@ -372,8 +372,9 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
         nu = self._initialise_nu()
 
         initial_binary_codes = jnp.asarray(
+            # TODO(Pawel): There could be a better way to initialize binary codes
             jax.random.bernoulli(
-                self._jax_rng.key, p=gamma, shape=(n_points, self._n_binary_codes)
+                self._jax_rng.key, p=0.1, shape=(n_points, self._n_binary_codes)
             ),
             dtype=float,
         )

--- a/src/jnotype/pyramids/_sampler_fixed.py
+++ b/src/jnotype/pyramids/_sampler_fixed.py
@@ -85,7 +85,7 @@ def _single_sampling_step(
         observed=observed,
         variances=variances,
         pseudoprior_variance=pseudoprior_variance,
-        gamma=gamma,
+        gamma=jnp.full_like(variances, gamma),
     )
     gamma = sample_gamma(
         key=subkey_gamma,

--- a/src/jnotype/pyramids/_sampler_fixed.py
+++ b/src/jnotype/pyramids/_sampler_fixed.py
@@ -1,6 +1,6 @@
 """Sampler for two-layer Bayesian pyramids
 with fixed number of latent binary codes."""
-from typing import Sequence
+from typing import Optional, Sequence, NewType
 
 import jax
 import jax.numpy as jnp
@@ -20,6 +20,9 @@ from jnotype.logistic import (
 )
 from jnotype._variance import sample_variances
 
+_JointSample = NewType("_JointSample", dict)
+_SplitSample = NewType("_SplitSample", dict)
+
 
 def _single_sampling_step(
     *,
@@ -36,6 +39,7 @@ def _single_sampling_step(
     covariates: Float[Array, "points covariates"],
     variances: Float[Array, " covariates"],
     gamma: Float[Array, ""],
+    nu: Float[Array, ""],
     cluster_labels: Int[Array, " points"],
     mixing: Float[Array, "n_binary_codes n_clusters"],
     proportions: Float[Array, " n_clusters"],
@@ -46,10 +50,12 @@ def _single_sampling_step(
     intercept_prior_variance: float = 1.0,
     gamma_prior_a: float = 1.0,
     gamma_prior_b: float = 1.0,
+    nu_prior_a: float = 1.0,
+    nu_prior_b: float = 1.0,
     variances_prior_shape: float = 2.0,
     variances_prior_scale: float = 1.0,
     mixing_beta_prior: tuple[float, float] = (1.0, 1.0),
-) -> dict:
+) -> _JointSample:
     """Single sampling step of two-layer Bayesian pyramid.
 
     Note:
@@ -60,6 +66,7 @@ def _single_sampling_step(
     # --- Sample the sparse logistic regression layer ---
     # Sample intercepts and coefficients
     key, subkey = jax.random.split(jax_key)
+
     intercepts, coefficients = sample_intercepts_and_coefficients(
         jax_key=subkey,
         numpy_rng=numpy_rng,
@@ -75,7 +82,15 @@ def _single_sampling_step(
     )
 
     # Sample structure and the sparsity
-    key, subkey_structure, subkey_gamma = jax.random.split(key, 3)
+    key, subkey_structure, subkey_gamma, subkey_nu = jax.random.split(key, 4)
+
+    n_observed_features = len(variances) - n_binary_codes
+    sparsity_vector = jnp.concatenate(
+        (
+            jnp.full(shape=(n_binary_codes,), fill_value=gamma),
+            jnp.full(shape=(n_observed_features,), fill_value=nu),
+        )
+    )
     structure = sample_structure(
         key=subkey_structure,
         intercepts=intercepts,
@@ -85,13 +100,19 @@ def _single_sampling_step(
         observed=observed,
         variances=variances,
         pseudoprior_variance=pseudoprior_variance,
-        gamma=jnp.full_like(variances, gamma),
+        gamma=sparsity_vector,
     )
     gamma = sample_gamma(
         key=subkey_gamma,
-        structure=structure,
+        structure=structure[..., :n_binary_codes],
         prior_a=gamma_prior_a,
         prior_b=gamma_prior_b,
+    )
+    nu = sample_gamma(
+        key=subkey_nu,
+        structure=structure[..., n_binary_codes:],
+        prior_a=nu_prior_a,
+        prior_b=nu_prior_b,
     )
 
     # Sample prior variances for coefficients
@@ -135,6 +156,7 @@ def _single_sampling_step(
         "coefficients": coefficients,
         "structure": structure,
         "gamma": gamma,
+        "nu": nu,
         "variances": variances,
         "covariates": covariates,
         "cluster_labels": cluster_labels,
@@ -143,12 +165,53 @@ def _single_sampling_step(
     }
 
 
+def _split_sample(n_binary_codes: int, sample: _JointSample) -> _SplitSample:
+    return {
+        "intercepts": sample["intercepts"],
+        "coefficients_latent": sample["coefficients"][:, :n_binary_codes],
+        "coefficients_observed": sample["coefficients"][:, n_binary_codes:],
+        "structure_latent": sample["structure"][:, :n_binary_codes],
+        "structure_observed": sample["structure"][:, n_binary_codes:],
+        "gamma": sample["gamma"],
+        "nu": sample["nu"],
+        "latent_variances": sample["variances"][:n_binary_codes],
+        "observed_variances": sample["variances"][n_binary_codes:],
+        "latent_traits": sample["covariates"][:, :n_binary_codes],
+        "cluster_labels": sample["cluster_labels"],
+        "proportions": sample["proportions"],
+        "mixing": sample["mixing"],
+    }
+
+
+def _merge_sample(
+    sample: _SplitSample,
+    observed_covariates: Float[Array, "points observed_covariates"],
+) -> _JointSample:
+    return {
+        "intercepts": sample["intercepts"],
+        "coefficients": jnp.hstack(
+            (sample["coefficients_latent"], sample["coefficients_observed"])
+        ),
+        "structure": jnp.hstack(
+            (sample["structure_latent"], sample["structure_observed"])
+        ),
+        "gamma": sample["gamma"],
+        "nu": sample["nu"],
+        "variances": jnp.concatenate(
+            (sample["latent_variances"], sample["observed_variances"])
+        ),
+        "covariates": jnp.hstack((sample["latent_traits"], observed_covariates)),
+        "cluster_labels": sample["cluster_labels"],
+        "proportions": sample["proportions"],
+        "mixing": sample["mixing"],
+    }
+
+
 class TwoLayerPyramidSampler(AbstractGibbsSampler):
     """A prototype of a Gibbs sampler for a two-layer
     Bayesian pyramid.
 
     Current limitations:
-      - No option to provide additional covariates.
       - Shrinkage on latent binary layer is not used.
     """
 
@@ -160,9 +223,13 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
         observed: Int[Array, "points features"],
         n_binary_codes: int = 8,
         n_clusters: int = 10,
+        observed_covariates: Optional[
+            Float[Array, "points observed_covariates"]
+        ] = None,
         # Prior
         dirichlet_prior: Float[Array, " clusters"],
         gamma_prior: tuple[float, float] = (1.0, 1.0),
+        nu_prior: tuple[float, float] = (1.0, 1.0),
         variances_prior_scale: float = 2.0,
         variances_prior_shape: float = 1.0,
         pseudoprior_variance: float = 0.1**2,
@@ -183,6 +250,13 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
         self._np_rng = np.random.default_rng(seed + 3)
 
         self._observed_data = observed
+        self._observed_covariates = (
+            observed_covariates
+            if observed_covariates is not None
+            else jnp.zeros((observed.shape[0], 0))
+        )
+        self._n_observed_covariates = self._observed_covariates.shape[1]
+
         assert n_clusters >= 1
         self._n_clusters = n_clusters
         assert n_binary_codes >= 1
@@ -190,6 +264,7 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
 
         self._dirichlet_prior = dirichlet_prior
         self._gamma_prior = gamma_prior
+        self._nu_prior = nu_prior
 
         # Variances of coefficients per each covariate in middle layer
         self._variances_prior_scale = variances_prior_scale
@@ -202,24 +277,30 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
         self._intercept_prior_variance = intercept_prior_variance
 
     @classmethod
-    def dimensions(cls) -> dict:
+    def dimensions(cls) -> _SplitSample:
         """The sites in each sample with annotated dimensions."""
         return {
             "intercepts": ["features"],
-            "coefficients": ["features", "latents"],
-            "structure": ["features", "latents"],
+            "coefficients_latent": ["features", "latents"],
+            "coefficients_observed": ["features", "observed_covariates"],
+            "structure_latent": ["features", "latents"],
+            "structure_observed": ["features", "observed_covariates"],
             "gamma": [],  # Float, no named dimensions
-            "variances": ["latents"],
-            "covariates": ["points", "latents"],
+            "nu": [],  # Float, no named dimensions
+            "latent_variances": ["latents"],
+            "observed_variances": ["observed_covariates"],
+            "latent_traits": ["points", "latents"],
             "cluster_labels": ["points"],
             "proportions": ["clusters"],
-            "mixing": ["latent_codes", "clusters"],
+            "mixing": ["latents", "clusters"],
         }
 
-    def new_sample(self, sample: dict) -> dict:
+    def new_sample(self, sample: _SplitSample) -> _SplitSample:
         """A new sample."""
-
-        return _single_sampling_step(
+        sample: _JointSample = _merge_sample(
+            sample=sample, observed_covariates=self._observed_covariates
+        )
+        new_sample: _JointSample = _single_sampling_step(
             jax_key=self._jax_rng.key,
             numpy_rng=self._np_rng,
             n_binary_codes=self._n_binary_codes,
@@ -230,12 +311,15 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
             covariates=sample["covariates"],
             variances=sample["variances"],
             gamma=sample["gamma"],
+            nu=sample["nu"],
             cluster_labels=sample["cluster_labels"],
             mixing=sample["mixing"],
             proportions=sample["proportions"],
             dirichlet_prior=self._dirichlet_prior,
             gamma_prior_a=self._gamma_prior[0],
             gamma_prior_b=self._gamma_prior[1],
+            nu_prior_a=self._nu_prior[0],
+            nu_prior_b=self._nu_prior[1],
             variances_prior_scale=self._variances_prior_scale,
             variances_prior_shape=self._variances_prior_shape,
             mixing_beta_prior=self._mixing_beta_prior,
@@ -243,6 +327,7 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
             intercept_prior_mean=self._intercept_prior_mean,
             intercept_prior_variance=self._intercept_prior_variance,
         )
+        return _split_sample(n_binary_codes=self._n_binary_codes, sample=new_sample)
 
     def _initialise_intercepts(self) -> Float[Array, " covariates"]:
         """Initializes the intercepts."""
@@ -258,38 +343,61 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
             self._jax_rng.key, self._gamma_prior[0], self._gamma_prior[1]
         )
 
-    def initialise(self) -> dict:
-        """Initialises the sample."""
+    def _initialise_nu(self) -> Float[Array, ""]:
+        return jax.random.beta(self._jax_rng.key, self._nu_prior[0], self._nu_prior[1])
+
+    def _initialise_structure(
+        self, gamma: Float[Array, ""], nu: Float[Array, ""]
+    ) -> Int[Array, ""]:
+        """Initialises the structure."""
+        n_outputs = self._observed_data.shape[1]
+        structure_codes = jax.random.bernoulli(
+            self._jax_rng.key, p=gamma, shape=(n_outputs, self._n_binary_codes)
+        )
+        structure_observed_features = jax.random.bernoulli(
+            self._jax_rng.key, p=nu, shape=(n_outputs, self._n_observed_covariates)
+        )
+        return jnp.hstack((structure_codes, structure_observed_features))
+
+    def _initialise_full_sample(self) -> _JointSample:
         # TODO(Pawel): This initialisation can be much improved.
         #   Hopefully it does not matter in the end, but assessment of
         #   chain mixing is very much required.
 
-        n_binary_codes = self._n_binary_codes
-        # TODO(Pawel): Update when covariates are allowed
-        n_covariates = self._n_binary_codes
+        n_covariates = self._n_binary_codes + self._n_observed_covariates
         n_points, n_outputs = self._observed_data.shape
         n_clusters = self._n_clusters
 
         gamma = self._initialise_gamma()
+        nu = self._initialise_nu()
+
+        initial_binary_codes = jnp.asarray(
+            jax.random.bernoulli(
+                self._jax_rng.key, p=gamma, shape=(n_points, self._n_binary_codes)
+            ),
+            dtype=float,
+        )
+        initial_covariates = jnp.hstack(
+            (initial_binary_codes, self._observed_covariates)
+        )
+
+        structure = self._initialise_structure(gamma=gamma, nu=nu)
+        variances = jnp.ones(n_covariates)
+
+        _noise = jax.random.normal(self._jax_rng.key, shape=(n_outputs, n_covariates))
+        _entries_variances = variances[
+            None, :
+        ] * structure + self._pseudoprior_variance * (1 - structure)
+        coefficients = jnp.sqrt(_entries_variances) * _noise
+
         return {
             "intercepts": self._initialise_intercepts(),
-            # TODO(Pawel): This doesn't really work this way:
-            #   some coefficients should be sampled from pseudoprior
-            #   and the others should be sampled from the prior
-            "coefficients": jnp.sqrt(self._pseudoprior_variance)
-            * jax.random.normal(self._jax_rng.key, shape=(n_outputs, n_covariates)),
-            "structure": jax.random.bernoulli(
-                self._jax_rng.key, p=gamma, shape=(n_outputs, n_covariates)
-            ),
+            "coefficients": coefficients,
+            "structure": self._initialise_structure(gamma=gamma, nu=nu),
             "gamma": gamma,
+            "nu": nu,
             "variances": jnp.ones(n_covariates),
-            # TODO(Pawel): Update when we allow additional covariates.
-            "covariates": jnp.asarray(
-                jax.random.bernoulli(
-                    self._jax_rng.key, p=0.1, shape=(n_points, n_covariates)
-                ),
-                dtype=float,
-            ),
+            "covariates": initial_covariates,
             "cluster_labels": jax.random.categorical(
                 self._jax_rng.key, logits=jnp.zeros(n_clusters), shape=(n_points,)
             ),
@@ -298,6 +406,12 @@ class TwoLayerPyramidSampler(AbstractGibbsSampler):
                 self._jax_rng.key,
                 a=self._mixing_beta_prior[0],
                 b=self._mixing_beta_prior[1],
-                shape=(n_binary_codes, n_clusters),
+                shape=(self._n_binary_codes, n_clusters),
             ),
         }
+
+    def initialise(self) -> _SplitSample:
+        """Initialises the sample."""
+        return _split_sample(
+            n_binary_codes=self._n_binary_codes, sample=self._initialise_full_sample()
+        )

--- a/src/jnotype/sampling/_chunker.py
+++ b/src/jnotype/sampling/_chunker.py
@@ -83,6 +83,9 @@ class ListDataset(DatasetInterface):
             "sample": np.arange(len(self.samples), dtype=int),
         } | self._coords
 
+        if not len(self.samples):
+            return xr.Dataset(coords=coords, attrs=attrs)
+
         variables = {
             label: (
                 self._coords_for_label(label),

--- a/tests/logistic/test_structure.py
+++ b/tests/logistic/test_structure.py
@@ -94,7 +94,7 @@ def test_sample_structure(
             observed=observed,
             variances=variances,
             pseudoprior_variance=pseudoprior,
-            gamma=gamma,
+            gamma=jnp.full_like(variances, fill_value=gamma),
         )
         samples.append(structure)
 


### PR DESCRIPTION
This PR adjusts the Gibbs sampler to use additional observed covariates (if provided, they are optional).