### PR TITLE
Reparameterizations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           version: ${{ matrix.poetry-version }}
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/econchick/interrogate

--- a/src/jnotype/_reparam.py
+++ b/src/jnotype/_reparam.py
@@ -48,7 +48,7 @@ def func_to_01(f: Callable[[PosNegArray], _T]) -> Callable[[BinaryArray], _T]:
 
     def g(x):
         """Composed function."""
-        return f(array_to_01(x))
+        return f(array_to_pos_neg(x))
 
     return g
 
@@ -63,7 +63,7 @@ def func_to_pos_neg(f: Callable[[BinaryArray], _T]) -> Callable[[PosNegArray], _
 
     def g(y):
         """Composed function."""
-        return f(array_to_pos_neg(y))
+        return f(array_to_01(y))
 
     return g
 

--- a/src/jnotype/_reparam.py
+++ b/src/jnotype/_reparam.py
@@ -1,0 +1,135 @@
+"""Reparameterizations of models defined on binary arrays."""
+
+from typing import Callable, NamedTuple, TypeVar, Sequence
+from collections import Counter
+import jax
+import jax.numpy as jnp
+from jaxtyping import Int, Array, Float
+
+PosNegArray = Int[Array, "N G"]
+BinaryArray = Int[Array, "N G"]
+
+
+def array_to_01(a: PosNegArray, dtype=int) -> BinaryArray:
+    """Converts an array from the +/- format to the 0/1 format.
+    Parameterization: 0 corresponds to +1. 1 corresponds to -1
+
+    Note:
+        0 corresponds to +1
+        1 corresponds to -1
+
+    Note:
+        This is the inverse to `array_to_pos_neg`.
+    """
+    return jnp.array(jnp.where(a < 0, 1, 0), dtype=dtype)
+
+
+def array_to_pos_neg(a: BinaryArray) -> PosNegArray:
+    """Converts an array from the 0/1 format to the +/- format.
+    Parameterization: 0 corresponds to +1. 1 corresponds to -1
+
+    Note:
+        This is the inverse to `array_to_01`.
+    """
+
+    return jnp.where(a, -1, 1)
+
+
+_T = TypeVar("_T")
+
+
+def func_to_01(f: Callable[[PosNegArray], _T]) -> Callable[[BinaryArray], _T]:
+    """Transforms a function taking the inputs arrays in +/- format
+    into an equivalent function taking as the inputs the arrays in 0/1 format.
+
+    Note:
+        The inverse to `func_to_pos_neg`
+    """
+
+    def g(x):
+        """Composed function."""
+        return f(array_to_01(x))
+
+    return g
+
+
+def func_to_pos_neg(f: Callable[[BinaryArray], _T]) -> Callable[[PosNegArray], _T]:
+    """Transforms a function taking the inputs arrays in 0/1 format
+    into an equivalent function taking as the inputs the arrays in +/- format.
+
+    Note:
+        The inverse to `func_to_01`
+    """
+
+    def g(y):
+        """Composed function."""
+        return f(array_to_pos_neg(y))
+
+    return g
+
+
+_Function = Callable[[Int[Array, " G"]], Float[Array, " "]]
+
+
+class EmpiricalBinaryVectorDistribution(NamedTuple):
+    """Stores an empirical distribution on binary vectors,
+    making it more efficient to calculate sums and means,
+    such as the loglikelihood.
+
+    Note:
+        This object should not be created directly.
+        Use `empirical_binary_vector_distribution`.
+    """
+
+    atoms: Int[Array, "K G"]
+    weights: Float[Array, " K"]
+    counts: Int[Array, " K"]
+    n_atoms: int
+    n_datapoints: int
+
+    def calculate_function_mean(self, f: _Function) -> Float[Array, " "]:
+        """Calculates the expected value E[f] over the empirical
+        distribution."""
+        values = jax.vmap(f)(self.atoms)
+        return jnp.dot(values, self.weights)
+
+    def calculate_function_sum(self, f: _Function) -> Float[Array, " "]:
+        """Calculates the weighted sum of `f` over all points in the distribution,
+        taking into account the multiplicities."""
+        values = jax.vmap(f)(self.atoms)
+        return jnp.dot(values, self.counts)
+
+
+def empirical_binary_vector_distribution(
+    vectors: Sequence[BinaryArray],
+) -> EmpiricalBinaryVectorDistribution:
+    """The factory method for `EmpiricalBinaryVectorDistribution`,
+    which wraps a collection of vectors into a distribution.
+
+    Raises:
+        ValueError: if any of the vectors is not 0/1 vector.
+    """
+    n_total = len(vectors)
+
+    for vector in vectors:
+        if jnp.min(vector) < 0 or jnp.max(vector) > 1:
+            raise ValueError("All entries must be from the set {0, 1}.")
+
+    cnt = Counter([tuple(vector.tolist()) for vector in vectors])
+
+    atoms = []
+    counts = []
+    for atom, n_occur in cnt.most_common(None):
+        atoms.append(atom)
+        counts.append(n_occur)
+
+    atoms = jnp.array(atoms, dtype=int)
+    counts = jnp.array(counts, dtype=int)
+
+    return EmpiricalBinaryVectorDistribution(
+        atoms=atoms,
+        counts=counts,
+        weights=jnp.array(counts, dtype=float) / n_total,
+        n_atoms=len(cnt),
+        n_datapoints=n_total,
+    )

--- a/src/jnotype/exclusivity/_rigid.py
+++ b/src/jnotype/exclusivity/_rigid.py
@@ -14,7 +14,7 @@ def _bincount(counts: Int[Array, " counts"], n_genes: int) -> Int[Array, " n_gen
 
 
 def _calculate_summary_statistic(
-    Y: Int[Array, "n_samples n_genes"]
+    Y: Int[Array, "n_samples n_genes"],
 ) -> Int[Array, " n_genes+1"]:
     """Calculates the summary statistic, counting the occurences of 1s."""
     return _bincount(counts=Y.sum(axis=-1), n_genes=Y.shape[-1])

--- a/tests/test_reparam.py
+++ b/tests/test_reparam.py
@@ -1,0 +1,54 @@
+import jax
+import jax.numpy as jnp
+import jnotype._reparam as re
+import numpy.testing as npt
+import pytest
+
+FUNCS = {
+    "dot": lambda x: jnp.dot(x, 2 * x),
+    "sum": lambda x: jnp.sum(x**2 + 3 * x - 2),
+}
+
+
+def test_array_conversions_simple():
+    a = jnp.asarray([0, 1, 0])
+    b = jnp.asarray([1, -1, 1])
+
+    npt.assert_array_equal(re.array_to_01(b), a)
+    npt.assert_array_equal(re.array_to_pos_neg(a), b)
+
+    for f_name, f in FUNCS.items():
+        print("Function: ", f_name)
+        npt.assert_allclose(
+            f(a),
+            re.func_to_pos_neg(f)(b),
+        )
+        npt.assert_allclose(
+            f(b),
+            re.func_to_01(f)(a),
+        )
+
+
+@pytest.mark.parametrize("shape", [(30,), (10, 2)])
+def test_array_conversions(shape, key=42):
+    key = jax.random.PRNGKey(key)
+    a = jax.random.bernoulli(key, p=0.3, shape=shape)
+    a_ = (-1) ** a
+
+    b = re.array_to_pos_neg(a)
+    assert b.shape == a.shape
+
+    npt.assert_array_equal(b, a_)
+    npt.assert_array_equal(re.array_to_01(b), a)
+
+    for f_name, f in FUNCS.items():
+        f = jax.vmap(f)
+        print("Function: ", f_name)
+        npt.assert_allclose(
+            f(a),
+            re.func_to_pos_neg(f)(b),
+        )
+        npt.assert_allclose(
+            f(b),
+            re.func_to_01(f)(a),
+        )

--- a/tests/test_reparam.py
+++ b/tests/test_reparam.py
@@ -52,3 +52,54 @@ def test_array_conversions(shape, key=42):
             f(b),
             re.func_to_01(f)(a),
         )
+
+
+@pytest.mark.parametrize("input_list", [True, False])
+def test_empirical_distribution_example(input_list: bool):
+    vectors = [
+        # ---
+        jnp.asarray([1, 1, 0]),
+        jnp.asarray([1, 1, 0]),
+        # ---
+        jnp.asarray([0, 1, 0]),
+        jnp.asarray([0, 1, 0]),
+        # ---
+        jnp.asarray([1, 1, 1]),
+        # ---
+        jnp.asarray([0, 0, 0]),
+    ]
+    if not input_list:
+        vectors = jnp.asarray(vectors)
+
+    dist = re.empirical_binary_vector_distribution(vectors)
+    assert dist.n_datapoints == 6
+    assert dist.n_atoms == 4
+    npt.assert_array_equal(dist.counts, jnp.asarray([2, 2, 1, 1]))
+    npt.assert_allclose(dist.weights, jnp.asarray([2 / 6, 2 / 6, 1 / 6, 1 / 6]))
+
+    atoms = jnp.asarray(
+        [
+            [1, 1, 0],
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 0, 0],
+        ]
+    )
+
+    npt.assert_array_equal(dist.atoms, atoms)
+
+
+@pytest.mark.parametrize("shape", [(15, 1), (10, 2), (30, 2)])
+@pytest.mark.parametrize("function_desc", FUNCS.items())
+def test_summaries_empirical_distribution(shape, function_desc, key=42):
+    key = jax.random.PRNGKey(key)
+    data = jax.random.bernoulli(key, p=0.3, shape=shape)
+
+    dist = re.empirical_binary_vector_distribution(data)
+
+    name, function = function_desc
+    print(name)
+    f_out = jax.vmap(function)(data)
+
+    assert pytest.approx(dist.calculate_function_mean(function)) == jnp.mean(f_out)
+    assert pytest.approx(dist.calculate_function_sum(function)) == jnp.sum(f_out)


### PR DESCRIPTION
Hi @allenxzhao,

This is an ongoing PR, which will provide an utility to speed up the likelihood and the DFD computations for binary data, by enumerating all vectors. The idea here is that for $G = 5$, we have up to $2^G = 32$ vectors, which should be considerably faster to evaluate than e.g., the likelihood for $N = 500$ or $N=5000$ vectors.

I need to add some tests here, but please feel free to this prototype in your work!