### PR TITLE
Add perturbed model

### DIFF
--- a/src/jnotype/_dirichlet.py
+++ b/src/jnotype/_dirichlet.py
@@ -2,7 +2,7 @@
 
 import jax
 import jax.numpy as jnp
-from jax.scipy.special import betaln
+from jax.scipy.special import betaln, gammaln
 import jnotype._reparam as reparam
 from functools import partial
 from typing import Callable, Sequence, TypeVar
@@ -10,6 +10,10 @@ from jaxtyping import Float, Array
 
 _Float = Float[Array, " "]
 _Param = TypeVar("_Param")
+
+
+def log_factorial(x):
+    return gammaln(x + 1)
 
 
 def construct_multinomial_loglikelihood(
@@ -29,11 +33,14 @@ def construct_multinomial_loglikelihood(
             params -> float
     """
     dataset = reparam.empirical_binary_vector_distribution(data)
+    log_const = log_factorial(dataset.n_datapoints) - jnp.sum(
+        log_factorial(dataset.counts)
+    )
 
     def f(param: _Param) -> _Float:
         """Function to be returned."""
         ll = partial(loglikelihood, param)
-        return dataset.calculate_function_sum(ll)
+        return log_const + dataset.calculate_function_sum(ll)
 
     return f
 
@@ -62,14 +69,53 @@ def construct_dirichlet_multinomial_loglikelihood(
           of signature (params, alpha) -> float
     """
     dataset = reparam.empirical_binary_vector_distribution(data)
+    n = dataset.n_datapoints
+    counts = dataset.counts
 
     def f(param: _Param, alpha: float) -> float:
         ll = partial(loglikelihood, param)
         log_F_theta = jax.vmap(ll)(dataset.atoms)
 
         parametric = _safe_exp(jnp.log(alpha) + log_F_theta, floor=_clamp)
-        return betaln(alpha, dataset.n_datapoints) - jnp.sum(
-            betaln(parametric, dataset.counts)
-        )
+        log_num = jnp.log(n) + betaln(alpha, n)
+        log_den = jnp.sum(betaln(parametric, counts) + jnp.log(counts))
+        return log_num - log_den
+
+    return f
+
+
+def construct_perturbed_loglikelihood(data, loglikelihood, _clamp: float = -80.0):
+    """Binds the loglikelihood function to the perturbed model.
+
+    Args:
+        data: binary array of shape (n_samples, n_loci)
+        loglikelihood: function of signature (params, genotype) -> float
+            calculating the loglikelihood for a single data point
+
+    Returns:
+        loglikelihood function for the whole data set
+          of signature (params, alpha, eta) -> float
+    """
+    dataset = reparam.empirical_binary_vector_distribution(data)
+    n = dataset.n_datapoints
+    counts = dataset.counts
+    log_const = log_factorial(dataset.n_datapoints) - jnp.sum(
+        log_factorial(dataset.counts)
+    )
+
+    def f(param: _Param, alpha: float, eta: float) -> float:
+        ll = partial(loglikelihood, param)
+        log_F_theta = jax.vmap(ll)(dataset.atoms)
+        logp_parametric = jnp.sum(log_F_theta) + log_const
+
+        alpha_F_theta = _safe_exp(jnp.log(alpha) + log_F_theta, floor=_clamp)
+        log_num = jnp.log(n) + betaln(alpha, n)
+        log_den = jnp.sum(betaln(alpha_F_theta, counts) + jnp.log(counts))
+        logp_nonparametric = log_num - log_den
+
+        log_eta = jnp.log(eta)
+        log_1meta = jnp.log1p(-eta)
+
+        return jnp.logaddexp(log_eta + logp_nonparametric, log_1meta + logp_parametric)
 
     return f

--- a/tests/test_dirichlet.py
+++ b/tests/test_dirichlet.py
@@ -1,0 +1,14 @@
+import jax.numpy as jnp
+import jnotype._dirichlet as dp
+import pytest
+
+
+def test_dirichlet_multinomial_reduces():
+    x = jnp.array([101, 20, 4, 1])
+    log_p = jnp.log(jnp.array([0.6, 0.05, 0.05, 0.29]))
+    alpha = 1e8
+
+    mult = dp.log_multinomial(x, log_p)
+    dir_mul = dp.log_dirichlet_multinomial(x, log_p, jnp.log(alpha))
+
+    assert dir_mul == pytest.approx(mult, rel=0.01)

--- a/workflows/nonparametric/20250417-Dirichlet_process.py
+++ b/workflows/nonparametric/20250417-Dirichlet_process.py
@@ -38,9 +38,9 @@ def ll_same_fn(theta, y):
 key = jax.random.PRNGKey(42)
 key, subkey = jax.random.split(key)
 
-p_true = jnp.asarray([0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5])
+p_true = jnp.asarray([0.1, 0.15, 0.2])  # , 0.25, 0.3, 0.35, 0.4, 0.5])
 n_genes = len(p_true)
-n_samples = 10
+n_samples = 2
 data = jax.random.bernoulli(key, p=p_true, shape=(n_samples, len(p_true)))
 
 # %%
@@ -82,13 +82,10 @@ loglike_perturbed = dp.construct_perturbed_loglikelihood(data, ll_fn)
 
 
 def perturbed_model():
-    # alpha = numpyro.sample("alpha", dist.HalfCauchy(5.0))
-
-    alpha = 10.0
+    alpha = numpyro.sample("alpha", dist.HalfCauchy(5.0))
 
     eta_conc = 6.0
     eta = numpyro.sample("eta", dist.Beta(eta_conc * 0.5, eta_conc * 0.5))
-    # eta = numpyro.sample("eta", dist.TruncatedNormal(loc=0.01, scale=0.2, low=0.001, high=1-0.001))
 
     conc1 = numpyro.sample("conc1", dist.Uniform(1, 10))
     conc0 = numpyro.sample("conc0", dist.Uniform(1, 10))
@@ -105,6 +102,18 @@ def dummy_dp_model():
     # p = numpyro.sample("probs", dist.Uniform(0, 1))
     numpyro.factor("loglikelihood", loglike_dummy(0.5, alpha))
 
+
+# %%
+loglike_multinomial(p_true)
+
+# %%
+loglike_dp(p_true, 5e9)
+
+# %%
+loglike_perturbed(p_true, 1e9, 0.000001)
+
+# %%
+loglike_perturbed(p_true, 2_000_000, 0.99999)
 
 # %% [markdown]
 # ## Inference in the parametric model

--- a/workflows/nonparametric/20250417-Dirichlet_process.py
+++ b/workflows/nonparametric/20250417-Dirichlet_process.py
@@ -17,6 +17,10 @@ import jax
 import jax.numpy as jnp
 import jnotype._dirichlet as dp
 
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import NUTS, MCMC
+
 
 # %%
 def ll_fn(theta, y):
@@ -36,21 +40,17 @@ key, subkey = jax.random.split(key)
 
 p_true = jnp.asarray([0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5])
 n_genes = len(p_true)
-n_samples = 1000
+n_samples = 10
 data = jax.random.bernoulli(key, p=p_true, shape=(n_samples, len(p_true)))
 
 # %%
-data2 = [[1] * n_genes] * 200
+data2 = [[1] * n_genes] * 2000 + [[0] * n_genes] * 2000
 data2 = jnp.asarray(data2)
 
 data = jnp.concatenate([data, data2])
 
+
 # %%
-import numpyro
-import numpyro.distributions as dist
-from numpyro.infer import NUTS, MCMC
-
-
 def reparam_ps(x):
     return x  #  * p_true
 
@@ -82,9 +82,12 @@ loglike_perturbed = dp.construct_perturbed_loglikelihood(data, ll_fn)
 
 
 def perturbed_model():
-    alpha = numpyro.sample("alpha", dist.HalfCauchy(5.0))
-    eta_conc = 10.0
-    eta = numpyro.sample("eta", dist.Beta(eta_conc * 0.2, eta_conc * 0.8))
+    # alpha = numpyro.sample("alpha", dist.HalfCauchy(5.0))
+
+    alpha = 10.0
+
+    eta_conc = 6.0
+    eta = numpyro.sample("eta", dist.Beta(eta_conc * 0.5, eta_conc * 0.5))
     # eta = numpyro.sample("eta", dist.TruncatedNormal(loc=0.01, scale=0.2, low=0.001, high=1-0.001))
 
     conc1 = numpyro.sample("conc1", dist.Uniform(1, 10))

--- a/workflows/nonparametric/20250417-Dirichlet_process.py
+++ b/workflows/nonparametric/20250417-Dirichlet_process.py
@@ -16,9 +16,6 @@
 import jax
 import jax.numpy as jnp
 import jnotype._dirichlet as dp
-import numpyro
-import numpyro.distributions as dist
-from numpyro.infer import NUTS, MCMC
 
 
 # %%
@@ -39,19 +36,25 @@ key, subkey = jax.random.split(key)
 
 p_true = jnp.asarray([0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.5])
 n_genes = len(p_true)
-n_samples = 5000
+n_samples = 1000
 data = jax.random.bernoulli(key, p=p_true, shape=(n_samples, len(p_true)))
 
 # %%
-data2 = [[0] * n_genes] * 8_000
+data2 = [[1] * n_genes] * 200
 data2 = jnp.asarray(data2)
 
 data = jnp.concatenate([data, data2])
 
 # %%
-# data = jnp.asarray([[1, 1, 0, 0, 0]] * 300 + [[0, 0, 1, 1, 1]] * 200)
+import numpyro
+import numpyro.distributions as dist
+from numpyro.infer import NUTS, MCMC
 
-# %%
+
+def reparam_ps(x):
+    return x  #  * p_true
+
+
 loglike_multinomial = dp.construct_multinomial_loglikelihood(data, ll_fn)
 
 
@@ -60,7 +63,7 @@ def multinomial_model():
     conc0 = numpyro.sample("conc0", dist.Uniform(1, 10))
     ps = numpyro.sample("probs", dist.Beta(conc1, conc0 * jnp.ones(n_genes)))
 
-    numpyro.factor("loglikelihood", loglike_multinomial(ps))
+    numpyro.factor("loglikelihood", loglike_multinomial(reparam_ps(ps)))
 
 
 loglike_dp = dp.construct_dirichlet_multinomial_loglikelihood(data, ll_fn)
@@ -72,7 +75,23 @@ def dp_model():
     conc0 = numpyro.sample("conc0", dist.Uniform(1, 10))
     ps = numpyro.sample("probs", dist.Beta(conc1, conc0 * jnp.ones(n_genes)))
 
-    numpyro.factor("loglikelihood", loglike_dp(ps, alpha))
+    numpyro.factor("loglikelihood", loglike_dp(reparam_ps(ps), alpha))
+
+
+loglike_perturbed = dp.construct_perturbed_loglikelihood(data, ll_fn)
+
+
+def perturbed_model():
+    alpha = numpyro.sample("alpha", dist.HalfCauchy(5.0))
+    eta_conc = 10.0
+    eta = numpyro.sample("eta", dist.Beta(eta_conc * 0.2, eta_conc * 0.8))
+    # eta = numpyro.sample("eta", dist.TruncatedNormal(loc=0.01, scale=0.2, low=0.001, high=1-0.001))
+
+    conc1 = numpyro.sample("conc1", dist.Uniform(1, 10))
+    conc0 = numpyro.sample("conc0", dist.Uniform(1, 10))
+    ps = numpyro.sample("probs", dist.Beta(conc1, conc0 * jnp.ones(n_genes)))
+
+    numpyro.factor("loglikelihood", loglike_perturbed(reparam_ps(ps), alpha, eta))
 
 
 loglike_dummy = dp.construct_dirichlet_multinomial_loglikelihood(data, ll_same_fn)
@@ -84,17 +103,35 @@ def dummy_dp_model():
     numpyro.factor("loglikelihood", loglike_dummy(0.5, alpha))
 
 
+# %% [markdown]
+# ## Inference in the parametric model
+
 # %%
 mcmc = MCMC(NUTS(multinomial_model), num_warmup=1000, num_samples=1000, num_chains=4)
 key, subkey = jax.random.split(key)
 mcmc.run(subkey)
 mcmc.print_summary()
 
+# %% [markdown]
+# ## Inference in the mixture of Dirichlet processes model
+
 # %%
 mcmc = MCMC(NUTS(dp_model), num_warmup=1000, num_samples=1000, num_chains=4)
 key, subkey = jax.random.split(key)
 mcmc.run(subkey)
 mcmc.print_summary()
+
+# %% [markdown]
+# ## Inference in the perturbed model
+
+# %%
+mcmc = MCMC(NUTS(perturbed_model), num_warmup=1000, num_samples=1000, num_chains=4)
+key, subkey = jax.random.split(key)
+mcmc.run(subkey)
+mcmc.print_summary()
+
+# %% [markdown]
+# ## Inference in the dummy model
 
 # %%
 mcmc = MCMC(NUTS(dummy_dp_model), num_warmup=1000, num_samples=1000, num_chains=4)


### PR DESCRIPTION
This PR adds the mixture model, perturbing a parametric model using a nonparametric one.

This implementation seems to be quite stable numerically (with the Dirichlet-multinomial reducing to the multinomial for large enough total concentration parameter. At least in some test settings, with some departures visible for more complex problems involving many data points), although the parametric model requires further tests before it can be fully trusted.

The next steps would be to create a Snakemake workflow with evaluation of all of these methods, allowing one to evaluate the predictive performance (rather than analyzing coefficients).